### PR TITLE
Vicwur/develop routing

### DIFF
--- a/vic/include/plugins/routing.h
+++ b/vic/include/plugins/routing.h
@@ -7,8 +7,8 @@
 
 enum{
     ROUTING_FALSE,
-    ROUTING_LOCAL,
-    ROUTING_GLOBAL
+    ROUTING_BASIN,
+    ROUTING_RANDOM
 };
 
 typedef struct{

--- a/vic/include/vic_def.h
+++ b/vic/include/vic_def.h
@@ -314,7 +314,7 @@ typedef struct {
 
     // Plugins
     bool GROUNDWATER;
-    int ROUTING;
+    bool ROUTING;
     bool ROUTING_RVIC;
     bool ROUTING_LOHMANN;
     bool WATER_USE;
@@ -326,6 +326,7 @@ typedef struct {
     // Groundwater options
     bool GW_INIT_FROM_FILE;    
     // Routing options
+    int ROUTING_TYPE;
     size_t RIRF_NSTEPS;
     size_t GIRF_NSTEPS;
     // Water use options

--- a/vic/src/get_global_param.c
+++ b/vic/src/get_global_param.c
@@ -569,7 +569,7 @@ get_global_param(FILE *gp)
     if (options.DAMS) {
         dam_validate_global_parameters();
     }
-    if (options.ROUTING != ROUTING_FALSE) {
+    if (options.ROUTING) {
         rout_validate_global_parameters();
     }
     if (options.EFR) {

--- a/vic/src/history_metadata.c
+++ b/vic/src/history_metadata.c
@@ -60,7 +60,7 @@ set_output_met_data_info()
     if (options.DAMS) {
         dam_set_output_meta_data_info();
     }
-    if (options.ROUTING != ROUTING_FALSE) {
+    if (options.ROUTING) {
         rout_set_output_meta_data_info();
     }
     if (options.IRRIGATION) {

--- a/vic/src/plugins/dams/dam_get_parameters.c
+++ b/vic/src/plugins/dams/dam_get_parameters.c
@@ -32,9 +32,9 @@ dam_validate_global_parameters(void)
     extern option_struct options;
     extern filenames_struct filenames;
     
-    if(options.ROUTING == ROUTING_FALSE){
+    if(!options.ROUTING){
         log_err("DAMS = TRUE but ROUTING = FALSE");
-    }  
+    }
     if(strcasecmp(filenames.dams.nc_filename, MISSING_S) == 0){
         log_err("DAMS = TRUE but DAMS_PARAMETERS is missing");
     }  

--- a/vic/src/plugins/dams/dam_put_data.c
+++ b/vic/src/plugins/dams/dam_put_data.c
@@ -12,7 +12,7 @@ dam_put_data(void)
     size_t i;    
     size_t j;
     
-        // Write to output struct
+    // Write to output struct
     int OUT_DAM_VOLUME = list_search_id(outvar_types, "OUT_DAM_VOLUME");
     int OUT_DAM_DISCHARGE = list_search_id(outvar_types, "OUT_DAM_DISCHARGE");
     int OUT_DAM_AREA = list_search_id(outvar_types, "OUT_DAM_AREA");
@@ -21,8 +21,6 @@ dam_put_data(void)
     int OUT_DAM_OP_VOLUME = list_search_id(outvar_types, "OUT_DAM_OP_VOLUME");
     int OUT_DAM_OP_MONTH = list_search_id(outvar_types, "OUT_DAM_OP_MONTH");
 
-    // If running with OpenMP, run this for loop using multiple threads
-    //#pragma omp parallel for default(shared) private(i, timer, vic_run_ref_str)
     for(i = 0; i < local_domain.ncells_active; i++){ 
         for(j = 0; j < dam_con_map[i].nd_active; j++){
             out_data[i][OUT_DAM_VOLUME][j] = dam_var[i][j].volume / pow(M_PER_KM, 2);

--- a/vic/src/plugins/efr/efr_put_data.c
+++ b/vic/src/plugins/efr/efr_put_data.c
@@ -12,8 +12,6 @@ efr_put_data(void)
 
     int OUT_EFR_REQUIREMENT = list_search_id(outvar_types, "OUT_EFR_REQUIREMENT");
     
-    // If running with OpenMP, run this for loop using multiple threads
-    //#pragma omp parallel for default(shared) private(i, timer, vic_run_ref_str)
     for(i = 0; i < local_domain.ncells_active; i++){ 
         out_data[i][OUT_EFR_REQUIREMENT][0] = efr_var[i].requirement;
     }    

--- a/vic/src/plugins/ext_mpi/ext_mpi_get_parameters.c
+++ b/vic/src/plugins/ext_mpi/ext_mpi_get_parameters.c
@@ -34,7 +34,7 @@ mpi_validate_global_parameters(void)
     extern int mpi_decomposition;
     
     if(mpi_decomposition == MPI_DECOMPOSITION_BASIN){
-        if(options.ROUTING == ROUTING_FALSE){
+        if(!options.ROUTING){
             log_err("MPI_DECOMPOSITION = MPI_DECOMPOSITION_BASIN but ROUTING = FALSE");
         }
     }

--- a/vic/src/plugins/groundwater/gw_put_data.c
+++ b/vic/src/plugins/groundwater/gw_put_data.c
@@ -25,8 +25,6 @@ gw_put_data(void)
     int OUT_GW_WT = list_search_id(outvar_types, "OUT_GW_WT");
     int OUT_GW_AVAIL = list_search_id(outvar_types, "OUT_GW_AVAIL");
     
-    // If running with OpenMP, run this for loop using multiple threads
-    //#pragma omp parallel for default(shared) private(i, timer, vic_run_ref_str)
     for(i = 0; i < local_domain.ncells_active; i++){        
         for(j=0; j < veg_con_map[i].nv_active; j++){
             veg_frac = veg_con[i][j].Cv;

--- a/vic/src/plugins/irrigation/irr_put_data.c
+++ b/vic/src/plugins/irrigation/irr_put_data.c
@@ -23,8 +23,6 @@ irr_put_data(void)
     int OUT_IRR_POND_STORAGE = list_search_id(outvar_types, "OUT_IRR_POND_STORAGE");
     int OUT_IRR_SHORTAGE = list_search_id(outvar_types, "OUT_IRR_SHORTAGE");
     
-    // If running with OpenMP, run this for loop using multiple threads
-    //#pragma omp parallel for default(shared) private(i, timer, vic_run_ref_str)
     for(i = 0; i < local_domain.ncells_active; i++){ 
         for(j = 0; j < irr_con_map[i].ni_active; j++){
             cur_veg = irr_con[i][j].veg_index;

--- a/vic/src/plugins/routing/rout_alloc_free.c
+++ b/vic/src/plugins/routing/rout_alloc_free.c
@@ -9,7 +9,6 @@ rout_alloc(void)
     extern rout_var_struct *rout_var;
     extern rout_con_struct *rout_con;
     extern size_t *routing_order;
-    extern int mpi_rank;
     
     size_t i;
     
@@ -19,14 +18,12 @@ rout_alloc(void)
     rout_con = malloc(local_domain.ncells_active * sizeof(*rout_con));
     check_alloc_status(rout_con,"Memory allocation error");
     
-    if(options.ROUTING == ROUTING_LOCAL){
+    if(options.ROUTING_TYPE == ROUTING_BASIN){
         routing_order = malloc(local_domain.ncells_active * sizeof(*routing_order));
         check_alloc_status(routing_order,"Memory allocation error");
-    } else if(options.ROUTING == ROUTING_GLOBAL){
-        if(mpi_rank == VIC_MPI_ROOT){
-            routing_order = malloc(global_domain.ncells_active * sizeof(*routing_order));
-            check_alloc_status(routing_order,"Memory allocation error");
-        }
+    } else if(options.ROUTING_TYPE == ROUTING_RANDOM){
+        routing_order = malloc(global_domain.ncells_active * sizeof(*routing_order));
+        check_alloc_status(routing_order,"Memory allocation error");
     }
         
     for(i=0; i<local_domain.ncells_active; i++){        

--- a/vic/src/plugins/routing/rout_get_parameters.c
+++ b/vic/src/plugins/routing/rout_get_parameters.c
@@ -14,15 +14,7 @@ rout_get_global_parameters(char *cmdstr)
     
     if (strcasecmp("ROUTING", optstr) == 0) {
         sscanf(cmdstr, "%*s %s", flgstr);
-        if(strcasecmp("FALSE", flgstr) == 0){
-            options.ROUTING = ROUTING_FALSE;
-        }else if(strcasecmp("LOCAL", flgstr) == 0){
-            options.ROUTING = ROUTING_LOCAL;
-        }else if(strcasecmp("GLOBAL", flgstr) == 0){
-            options.ROUTING = ROUTING_GLOBAL;
-        }else{
-            log_err("ROUTING should be FALSE, LOCAL or GLOBAL; %s is unknown", flgstr);
-        }
+        options.ROUTING = str_to_bool(flgstr);
     } 
     else if (strcasecmp("ROUTING_PARAMETERS", optstr) == 0) {
         sscanf(cmdstr, "%*s %s", filenames.routing.nc_filename);
@@ -42,9 +34,12 @@ rout_validate_global_parameters(void)
     extern filenames_struct filenames;
     extern int mpi_decomposition;
     
-    if(mpi_decomposition == MPI_DECOMPOSITION_RANDOM && options.ROUTING == ROUTING_LOCAL){
-        log_err("ROUTING = ROUTING_LOCAL but MPI_DECOMPOSITION = MPI_DECOMPOSITION_RANDOM");
+    if(mpi_decomposition == MPI_DECOMPOSITION_RANDOM){
+        options.ROUTING_TYPE = ROUTING_RANDOM;
+    } else {
+        options.ROUTING_TYPE = ROUTING_BASIN;
     }
+    
     if(strcasecmp(filenames.routing.nc_filename, MISSING_S) == 0){
         log_err("ROUTING = TRUE but ROUTING_PARAMETERS is missing");
     }  

--- a/vic/src/plugins/routing/rout_init.c
+++ b/vic/src/plugins/routing/rout_init.c
@@ -627,11 +627,11 @@ rout_init(void)
     rout_set_uh();
     rout_set_direction();
     
-    if(options.ROUTING == ROUTING_LOCAL){
+    if(options.ROUTING_TYPE == ROUTING_BASIN){
         rout_set_downstream();
         rout_set_upstream();
         rout_set_order();
-    } else if (options.ROUTING == ROUTING_GLOBAL){
+    } else if (options.ROUTING_TYPE == ROUTING_RANDOM){
         rout_gl_set_downstream();
         rout_gl_set_upstream();
         rout_gl_set_order();

--- a/vic/src/plugins/routing/rout_put_data.c
+++ b/vic/src/plugins/routing/rout_put_data.c
@@ -14,8 +14,6 @@ rout_put_data(void)
     int OUT_NAT_DISCHARGE = list_search_id(outvar_types, "OUT_NAT_DISCHARGE");
     int OUT_STREAM_MOIST = list_search_id(outvar_types, "OUT_STREAM_MOIST");
     
-    // If running with OpenMP, run this for loop using multiple threads
-    //#pragma omp parallel for default(shared) private(i, timer, vic_run_ref_str)
     for(i = 0; i < local_domain.ncells_active; i++){ 
         out_data[i][OUT_STREAM_MOIST][0] = rout_var[i].storage;
         out_data[i][OUT_DISCHARGE][0] = rout_var[i].discharge[0];

--- a/vic/src/plugins/water_use/wu_get_parameters.c
+++ b/vic/src/plugins/water_use/wu_get_parameters.c
@@ -120,7 +120,7 @@ wu_validate_global_parameters(void)
     
     size_t i;
     
-    if(options.ROUTING == ROUTING_FALSE){
+    if(!options.ROUTING){
         log_err("WATER_USE = TRUE but ROUTING = FALSE");
     }
     if(strcasecmp(filenames.water_use_forcing_pfx, MISSING_S) == 0 &&

--- a/vic/src/plugins/water_use/wu_put_data.c
+++ b/vic/src/plugins/water_use/wu_put_data.c
@@ -16,8 +16,6 @@ wu_put_data(void)
     int OUT_WU_CONSUMED = list_search_id(outvar_types, "OUT_WU_CONSUMED");
     int OUT_WU_RETURNED = list_search_id(outvar_types, "OUT_WU_RETURNED");
     
-    // If running with OpenMP, run this for loop using multiple threads
-    //#pragma omp parallel for default(shared) private(i, timer, vic_run_ref_str)
     for(i = 0; i < local_domain.ncells_active; i++){ 
         for(j = 0; j < WU_NSECTORS; j++){
             out_data[i][OUT_WU_DEMAND][j] = wu_var[i][j].demand;

--- a/vic/src/vic_alloc.c
+++ b/vic/src/vic_alloc.c
@@ -46,7 +46,7 @@ vic_alloc(void) {
     if (options.DAMS) {
         dam_add_types();
     }
-    if (options.ROUTING != ROUTING_FALSE) {
+    if (options.ROUTING) {
         rout_add_types();
     }
     if (options.IRRIGATION) {
@@ -74,7 +74,7 @@ vic_alloc(void) {
     if (options.DAMS) {
         dam_alloc();
     }
-    if (options.ROUTING != ROUTING_FALSE) {
+    if (options.ROUTING) {
         rout_alloc();
     }
     if (options.EFR) {

--- a/vic/src/vic_finalize.c
+++ b/vic/src/vic_finalize.c
@@ -41,7 +41,7 @@ vic_finalize(void)
     if (options.DAMS) {
         dam_finalize();
     }
-    if (options.ROUTING != ROUTING_FALSE) {
+    if (options.ROUTING) {
         rout_finalize();
     }
     if (options.IRRIGATION) {

--- a/vic/src/vic_image_run.c
+++ b/vic/src/vic_image_run.c
@@ -65,7 +65,7 @@ vic_image_run(dmy_struct *dmy_current)
     }
         
     // If running with OpenMP, run this for loop using multiple threads
-    //#pragma omp parallel for default(shared) private(i, timer, vic_run_ref_str)
+    #pragma omp parallel for default(shared) private(i, timer, vic_run_ref_str)
     for (i = 0; i < local_domain.ncells_active; i++) {
         // Set global reference string (for debugging inside vic_run)
         sprintf(vic_run_ref_str, "Gridcell io_idx: %zu, timestep info: %s",
@@ -88,13 +88,13 @@ vic_image_run(dmy_struct *dmy_current)
         if(options.IRRIGATION){
             irr_run(i);
         } 
+        
         timer_stop(&timer);
     }
         
     // If running with OpenMP, run this for loop using multiple threads
-    //#pragma omp parallel for default(shared) private(i, timer, vic_run_ref_str)
+    #pragma omp parallel for default(shared) private(i)
     for (i = 0; i < local_domain.ncells_active; i++) {
-        // TODO: set reference strings
         put_data(&(all_vars[i]), &(force[i]), &(soil_con[i]), veg_con[i],
                  veg_lib[i], &lake_con, out_data[i], &(save_data[i]),
                  &timer);
@@ -103,9 +103,7 @@ vic_image_run(dmy_struct *dmy_current)
     if (options.ROUTING_RVIC) {
         routing_rvic_run();
     }    
-    if (options.ROUTING == ROUTING_LOCAL) {
-        // If running with OpenMP, run this for loop using multiple threads
-        //#pragma omp parallel for default(shared) private(i, timer, vic_run_ref_str)
+    if (options.ROUTING_TYPE == ROUTING_BASIN) {
         for(i = 0; i < local_domain.ncells_active; i++){
             cur_cell = routing_order[i];
 
@@ -134,24 +132,25 @@ vic_image_run(dmy_struct *dmy_current)
                 }
             }
         }
-    } else if (options.ROUTING == ROUTING_GLOBAL){
+    } else if (options.ROUTING_TYPE == ROUTING_RANDOM){
+        
         rout_gl_run();
         
         if(options.EFR){
-            log_err("EFR is not yet available with ROUTING_GLOBAL");
+            log_err("EFR is not yet available with ROUTING_RANDOM");
         }
         if(options.DAMS){
-            log_err("DAMS is not yet available with ROUTING_GLOBAL");
+            log_err("DAMS is not yet available with ROUTING_RANDOM");
         }
         if(options.WATER_USE){
-            log_err("WATER_USE is not yet available with ROUTING_GLOBAL");
+            log_err("WATER_USE is not yet available with ROUTING_RANDOM");
         }
     }
     
     if(options.GROUNDWATER){
         gw_put_data();
     }
-    if(options.ROUTING != ROUTING_FALSE){
+    if(options.ROUTING){
         rout_put_data();
     }
     if(options.EFR){

--- a/vic/src/vic_init.c
+++ b/vic/src/vic_init.c
@@ -44,7 +44,7 @@ vic_init(void)
         initialize_dam_local_structures();
         dam_init();
     }
-    if (options.ROUTING != ROUTING_FALSE) {
+    if (options.ROUTING) {
         initialize_rout_local_structures();
         rout_init();
     }

--- a/vic/src/vic_start.c
+++ b/vic/src/vic_start.c
@@ -158,7 +158,7 @@ vic_start(void)
         }
         
         // plugins
-        if (options.ROUTING != ROUTING_FALSE) {
+        if (options.ROUTING) {
             rout_start();
         }
         if (options.DAMS) {

--- a/vic/src/vicwur/main_functions/display_current_settings.c
+++ b/vic/src/vicwur/main_functions/display_current_settings.c
@@ -255,7 +255,7 @@ display_current_settings(int mode)
     else {
         fprintf(LOG_DEST, "GROUNDWATER\t\tFALSE\n");
     }
-    if (options.ROUTING != ROUTING_FALSE) {
+    if (options.ROUTING) {
         fprintf(LOG_DEST, "ROUTING\t\tTRUE\n");
     }
     else if (options.ROUTING_LOHMANN) {

--- a/vic/src/vicwur/main_functions/initialize_options.c
+++ b/vic/src/vicwur/main_functions/initialize_options.c
@@ -110,6 +110,7 @@ initialize_options()
     // Groundwater options
     options.GW_INIT_FROM_FILE = false;
     // Routing options
+    options.ROUTING_TYPE = ROUTING_FALSE;
     options.RIRF_NSTEPS = 0;
     options.GIRF_NSTEPS = 0;
     // Water use options

--- a/vic/src/vicwur/main_functions/vic_mpi_support.c
+++ b/vic/src/vicwur/main_functions/vic_mpi_support.c
@@ -487,7 +487,7 @@ create_MPI_option_struct_type(MPI_Datatype *mpi_type)
     MPI_Datatype   *mpi_types;
 
     // nitems has to equal the number of elements in option_struct
-    nitems = 75;
+    nitems = 76;
     blocklengths = malloc(nitems * sizeof(*blocklengths));
     check_alloc_status(blocklengths, "Memory allocation error.");
 
@@ -728,7 +728,7 @@ create_MPI_option_struct_type(MPI_Datatype *mpi_type)
     mpi_types[i++] = MPI_C_BOOL;
     // bool ROUTING;
     offsets[i] = offsetof(option_struct, ROUTING);
-    mpi_types[i++] = MPI_INT;
+    mpi_types[i++] = MPI_C_BOOL;
     // bool WATER_USE;
     offsets[i] = offsetof(option_struct, WATER_USE);
     mpi_types[i++] = MPI_C_BOOL;
@@ -746,6 +746,9 @@ create_MPI_option_struct_type(MPI_Datatype *mpi_type)
     offsets[i] = offsetof(option_struct, GW_INIT_FROM_FILE);
     mpi_types[i++] = MPI_C_BOOL; 
     
+    // int ROUTING_TYPE;
+    offsets[i] = offsetof(option_struct, ROUTING_TYPE);
+    mpi_types[i++] = MPI_INT;
     // size_t RIRF_NSTEPS;
     offsets[i] = offsetof(option_struct, RIRF_NSTEPS);
     mpi_types[i++] = MPI_AINT;


### PR DESCRIPTION
**Changed routing to automatically adapt based on mpi decomposition method and removed redundant openmp calls while re-enabling openmp for VIC**.
1. The routing option has been split into two separate variables: one to identify if routing is enabled and the other to identify the routing type (with a random mpi decomposition or a basin mpi decomposition). The routing type is used in the allocation, initialization and running of the routing module. Currently other modules such as: dams, water use and efr can only be run with basin mpi decomposition.
2. The calls to openmp were disabled for debugging purposes. They are enabled for vic_run and vic_put_data and have been removed for the plugins since the plugins are not yet able to function with openmp. This should be made possible in the future.