### PR TITLE
Vicwur/develop forcing

### DIFF
--- a/vic/include/vic_def.h
+++ b/vic/include/vic_def.h
@@ -115,6 +115,31 @@ enum
 };
 
 /******************************************************************************
+ * @brief   Forcing Variable Types
+ *****************************************************************************/
+enum
+{
+    AIR_TEMP,    /**< air temperature per time step [C] */
+    ALBEDO,      /**< surface albedo [fraction] */
+    CATM,        /**< atmospheric CO2 concentration [ppm] */
+    CHANNEL_IN,  /**< incoming channel flow [m3] */
+    FCANOPY,     /**< fractional area covered by plant canopy [fraction] */
+    FDIR,        /**< fraction of incoming shortwave that is direct [fraction] */
+    LAI,         /**< leaf area index [m2/m2] */
+    LWDOWN,      /**< incoming longwave radiation [W/m2] */
+    PAR,         /**< incoming photosynthetically active radiation [W/m2] */
+    PREC,        /**< total precipitation (rain and snow) [mm] */
+    PRESSURE,    /**< atmospheric pressure [kPa] */
+    VP,          /**< vapor pressure [kPa] */
+    SWDOWN,      /**< incoming shortwave [W/m2] */
+    WIND,        /**< wind speed [m/s] */
+    SKIP,        /**< place holder for unused data columns */
+    // Last value of enum - DO NOT ADD ANYTHING BELOW THIS LINE!!
+    // used as a loop counter and must be >= the largest value in this enum
+    N_FORCING_TYPES  /**< Number of forcing types */
+};
+
+/******************************************************************************
  * @brief   Baseflow parametrizations
  *****************************************************************************/
 enum
@@ -365,15 +390,15 @@ typedef struct {
     unsigned short int endday;     /**< Last day of model simulation */
     unsigned short int endmonth;   /**< Last month of model simulation */
     unsigned short int endyear;    /**< Last year of model simulation */
-    unsigned short int forceday[2];  /**< day forcing files starts */
-    unsigned int forcesec[2];          /**< seconds since midnight when forcing
+    unsigned short int forceday[N_FORCING_TYPES];  /**< day forcing files starts */
+    unsigned int forcesec[N_FORCING_TYPES];          /**< seconds since midnight when forcing
                                           files starts */
-    unsigned short int forcemonth[2];  /**< month forcing files starts */
-    unsigned short int forceoffset[2];  /**< counter to keep track of offset in reading
+    unsigned short int forcemonth[N_FORCING_TYPES];  /**< month forcing files starts */
+    unsigned short int forceoffset[N_FORCING_TYPES];  /**< counter to keep track of offset in reading
                                            forcing files; updated after every read */
-    unsigned int forceskip[2];   /**< number of model time steps to skip at
+    unsigned int forceskip[N_FORCING_TYPES];   /**< number of model time steps to skip at
                                       the start of the forcing file */
-    unsigned short int forceyear[2];  /**< year forcing files start */
+    unsigned short int forceyear[N_FORCING_TYPES];  /**< year forcing files start */
     size_t nrecs;                /**< Number of time steps simulated */
     unsigned short int startday;  /**< Starting day of the simulation */
     unsigned short int startmonth;  /**< Starting month of the simulation */

--- a/vic/include/vic_general.h
+++ b/vic/include/vic_general.h
@@ -454,11 +454,7 @@ enum timers
  * @brief    Stores forcing file input information.
  *****************************************************************************/
 typedef struct {
-    size_t N_ELEM; /**< number of elements per record; for LAI and ALBEDO,
-                        1 element per veg tile; for others N_ELEM = 1; */
-    bool SIGNED;
     bool SUPPLIED;
-    double multiplier;
     char varname[MAXSTRING];
 } force_type_struct;
 
@@ -469,13 +465,7 @@ typedef struct {
  *****************************************************************************/
 typedef struct {
     force_type_struct TYPE[N_FORCING_TYPES];
-    double FORCE_DT[N_FORCING_TYPES];    /**< forcing file time step */
     size_t force_steps_per_day[N_FORCING_TYPES];    /**< forcing file timesteps per day */
-    unsigned short int FORCE_ENDIAN[N_FORCING_TYPES];  /**< endian-ness of input file, used for
-                                            DAILY_BINARY format */
-    int FORCE_FORMAT[N_FORCING_TYPES];            /**< ASCII or BINARY */
-    int FORCE_INDEX[N_FORCING_TYPES][1];
-    size_t N_TYPES[N_FORCING_TYPES];
 } param_set_struct;
 
 /******************************************************************************

--- a/vic/include/vic_general.h
+++ b/vic/include/vic_general.h
@@ -35,7 +35,6 @@
 #define AREA_SUM_ERROR_THRESH 1e-10
 
 // Define maximum array sizes for driver level objects
-#define MAX_FORCE_FILES 2
 #define MAX_OUTPUT_STREAMS 20
 
 // Output compression setting
@@ -93,31 +92,6 @@ enum
     FROM_VEGLIB,
     FROM_VEGPARAM,
     FROM_VEGHIST
-};
-
-/******************************************************************************
- * @brief   Forcing Variable Types
- *****************************************************************************/
-enum
-{
-    AIR_TEMP,    /**< air temperature per time step [C] */
-    ALBEDO,      /**< surface albedo [fraction] */
-    CATM,        /**< atmospheric CO2 concentration [ppm] */
-    CHANNEL_IN,  /**< incoming channel flow [m3] */
-    FCANOPY,     /**< fractional area covered by plant canopy [fraction] */
-    FDIR,        /**< fraction of incoming shortwave that is direct [fraction] */
-    LAI,         /**< leaf area index [m2/m2] */
-    LWDOWN,      /**< incoming longwave radiation [W/m2] */
-    PAR,         /**< incoming photosynthetically active radiation [W/m2] */
-    PREC,        /**< total precipitation (rain and snow) [mm] */
-    PRESSURE,    /**< atmospheric pressure [kPa] */
-    VP,          /**< vapor pressure [kPa] */
-    SWDOWN,      /**< incoming shortwave [W/m2] */
-    WIND,        /**< wind speed [m/s] */
-    SKIP,        /**< place holder for unused data columns */
-    // Last value of enum - DO NOT ADD ANYTHING BELOW THIS LINE!!
-    // used as a loop counter and must be >= the largest value in this enum
-    N_FORCING_TYPES  /**< Number of forcing types */
 };
 
 
@@ -495,13 +469,13 @@ typedef struct {
  *****************************************************************************/
 typedef struct {
     force_type_struct TYPE[N_FORCING_TYPES];
-    double FORCE_DT[2];    /**< forcing file time step */
-    size_t force_steps_per_day[2];    /**< forcing file timesteps per day */
-    unsigned short int FORCE_ENDIAN[2];  /**< endian-ness of input file, used for
+    double FORCE_DT[N_FORCING_TYPES];    /**< forcing file time step */
+    size_t force_steps_per_day[N_FORCING_TYPES];    /**< forcing file timesteps per day */
+    unsigned short int FORCE_ENDIAN[N_FORCING_TYPES];  /**< endian-ness of input file, used for
                                             DAILY_BINARY format */
-    int FORCE_FORMAT[2];            /**< ASCII or BINARY */
-    int FORCE_INDEX[2][N_FORCING_TYPES];
-    size_t N_TYPES[2];
+    int FORCE_FORMAT[N_FORCING_TYPES];            /**< ASCII or BINARY */
+    int FORCE_INDEX[N_FORCING_TYPES][1];
+    size_t N_TYPES[N_FORCING_TYPES];
 } param_set_struct;
 
 /******************************************************************************
@@ -733,8 +707,8 @@ typedef struct {
  * @brief   This structure stores input and output filenames.
  *****************************************************************************/
 typedef struct {
-    nameid_struct forcing[MAX_FORCE_FILES];  /**< atmospheric forcing files */
-    char f_path_pfx[MAX_FORCE_FILES][MAXSTRING]; /**< path and prefix for
+    nameid_struct forcing[N_FORCING_TYPES];  /**< atmospheric forcing files */
+    char f_path_pfx[N_FORCING_TYPES][MAXSTRING]; /**< path and prefix for
                                                     atmospheric forcing files */
     char global[MAXSTRING];     /**< global control file name */
     nameid_struct domain;       /**< domain file name and nc_id*/
@@ -817,6 +791,7 @@ void initialize_energy(energy_bal_struct **energy, size_t nveg);
 void initialize_global(void);
 void initialize_options(void);
 void initialize_parameters(void);
+void initialize_param_set(void);
 void initialize_save_data(all_vars_struct *all_vars, force_data_struct *force,
                           soil_con_struct *soil_con, veg_con_struct *veg_con,
                           veg_lib_struct *veg_lib, lake_con_struct *lake_con,
@@ -972,7 +947,7 @@ void print_nc_file(nc_file_struct *nc);
 void print_nc_var(nc_var_struct *nc_var);
 void print_veg_con_map(veg_con_map_struct *veg_con_map);
 void put_nc_attr(int nc_id, int var_id, const char *name, const char *value);
-void set_force_type(char *cmdstr, int file_num, int *field);
+void set_force_type(char *cmdstr);
 void set_global_nc_attributes(int ncid, unsigned short int file_type);
 void set_state_meta_data_info();
 void set_nc_var_dimids(unsigned int varid, nc_file_struct *nc_hist_file,

--- a/vic/src/get_global_param.c
+++ b/vic/src/get_global_param.c
@@ -827,11 +827,7 @@ get_global_param(FILE *gp)
                         "defined.  Make sure that the global file defines "
                         "FORCE_STEPS_PER_DAY.");
             }
-            else {
-                param_set.FORCE_DT[i] = SEC_PER_DAY /
-                                        (double) param_set.force_steps_per_day[i];
-            }
-        }        
+        }    
     }
 
     // Validate result directory

--- a/vic/src/get_global_param.c
+++ b/vic/src/get_global_param.c
@@ -786,17 +786,29 @@ get_global_param(FILE *gp)
         // Validate forcing files and variables
         if (strcmp(filenames.f_path_pfx[i], "MISSING") == 0) {
             if(i == AIR_TEMP || i == LWDOWN || i == PREC || 
-                    i == PRESSURE || i == VP || i == SWDOWN || i == WIND ||
-                    (i == FCANOPY && options.FCAN_SRC == FROM_VEGHIST) || 
+                    i == PRESSURE || i == VP || i == SWDOWN || i == WIND){
+                log_err("Not all essential forcing files have been defined. "
+                        "Make sure to define forcing files for at least: "
+                        "AIR_TEMP, LWDOWN, PREC, PRESSURE, VP, SWDOWN and WIND");
+            } else if ((i == FCANOPY && options.FCAN_SRC == FROM_VEGHIST) || 
                     (i == LAI && options.LAI_SRC == FROM_VEGHIST) || 
-                    (i == ALBEDO && options.ALB_SRC == FROM_VEGHIST) || 
-                    (i == CHANNEL_IN && options.LAKES) ||
-                    (i == CATM && options.CARBON) ||
+                    (i == ALBEDO && options.ALB_SRC == FROM_VEGHIST)){
+                log_err("Not all essential forcing files have been defined. "
+                        "Make sure, if FROM_VEGHIST is selected, "
+                        "to define forcing for: "
+                        "FACANOPY, LAI and ALDBEDO");
+            } else if ((i == CHANNEL_IN && options.LAKES)) {
+                log_err("Not all essential forcing files have been defined. "
+                        "Make sure, if LAKES is selected, "
+                        "to define forcing for: "
+                        "CHANNEL_IN");
+            } else if ((i == CATM && options.CARBON) ||
                     (i == FDIR && options.CARBON) ||
                     (i == PAR && options.CARBON)){
                 log_err("Not all essential forcing files have been defined. "
-                        "Make sure to define forcing files for at least:"
-                        "AIR_TEMP, LWDOWN, PREC, PRESSURE, VP, SWDOWN and WIND");
+                        "Make sure, if CARBON is selected, "
+                        "to define forcing for: "
+                        "CATM, FDIR and PAR");
             }
         } else {
             // Get information from the forcing file(s)

--- a/vic/src/get_global_param.c
+++ b/vic/src/get_global_param.c
@@ -44,13 +44,12 @@ get_global_param(FILE *gp)
     char                       optstr[MAXSTRING];
     char                       flgstr[MAXSTRING];
     char                       flgstr2[MAXSTRING];
-    size_t                     file_num;
-    int                        field;
     int                        status;
     unsigned int               tmpstartdate;
     unsigned int               tmpenddate;
     unsigned short int         lastday[MONTHS_PER_YEAR];
 
+    size_t i;
 
     /** Read through global control file to find parameters **/
 
@@ -353,30 +352,8 @@ get_global_param(FILE *gp)
             /*************************************
                Define forcing files
             *************************************/
-            else if (strcasecmp("FORCING1", optstr) == 0) {
-                if (strcmp(filenames.f_path_pfx[0], "MISSING") != 0) {
-                    log_err("Tried to define FORCING1 twice, if you want to "
-                            "use two forcing files, the second must be "
-                            "defined as FORCING2");
-                }
-                sscanf(cmdstr, "%*s %s", filenames.f_path_pfx[0]);
-                file_num = 0;
-                field = 0;
-                // count the number of forcing variables in this file
-                param_set.N_TYPES[file_num] = count_force_vars(gp);
-            }
-            else if (strcasecmp("FORCING2", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", filenames.f_path_pfx[1]);
-                if (strcasecmp("FALSE", filenames.f_path_pfx[1]) == 0) {
-                    strcpy(filenames.f_path_pfx[1], "MISSING");
-                }
-                file_num = 1;
-                field = 0;
-                // count the number of forcing variables in this file
-                param_set.N_TYPES[file_num] = count_force_vars(gp);
-            }
             else if (strcasecmp("FORCE_TYPE", optstr) == 0) {
-                set_force_type(cmdstr, file_num, &field);
+                set_force_type(cmdstr);
             }
             else if (strcasecmp("WIND_H", optstr) == 0) {
                 sscanf(cmdstr, "%*s %lf", &global_param.wind_h);
@@ -805,54 +782,44 @@ get_global_param(FILE *gp)
                 "for NRECS.", global_param.nrecs);
     }
 
-    // Validate forcing files and variables
-    if (strcmp(filenames.f_path_pfx[0], "MISSING") == 0) {
-        log_err("No forcing file has been defined.  Make sure that the global "
-                "file defines FORCING1.");
-    }
+    for(i = 0; i < N_FORCING_TYPES; i++){
+        // Validate forcing files and variables
+        if (strcmp(filenames.f_path_pfx[i], "MISSING") == 0) {
+            if(i == AIR_TEMP || i == LWDOWN || i == PREC || 
+                    i == PRESSURE || i == VP || i == SWDOWN || i == WIND ||
+                    (i == FCANOPY && options.FCAN_SRC == FROM_VEGHIST) || 
+                    (i == LAI && options.LAI_SRC == FROM_VEGHIST) || 
+                    (i == ALBEDO && options.ALB_SRC == FROM_VEGHIST) || 
+                    (i == CHANNEL_IN && options.LAKES) ||
+                    (i == CATM && options.CARBON) ||
+                    (i == FDIR && options.CARBON) ||
+                    (i == PAR && options.CARBON)){
+                log_err("Not all essential forcing files have been defined. "
+                        "Make sure to define forcing files for at least:"
+                        "AIR_TEMP, LWDOWN, PREC, PRESSURE, VP, SWDOWN and WIND");
+            }
+        } else {
+            // Get information from the forcing file(s)
+            // Open first-year forcing files and get info
+            sprintf(filenames.forcing[i].nc_filename, "%s%4d.nc",
+                    filenames.f_path_pfx[i], global_param.startyear);
+            status = nc_open(filenames.forcing[i].nc_filename, NC_NOWRITE,
+                             &(filenames.forcing[i].nc_id));
+            check_nc_status(status, "Error opening %s",
+                            filenames.forcing[i].nc_filename);
 
-    // Get information from the forcing file(s)
-    // Open first-year forcing files and get info
-    sprintf(filenames.forcing[0].nc_filename, "%s%4d.nc",
-            filenames.f_path_pfx[0], global_param.startyear);
-    status = nc_open(filenames.forcing[0].nc_filename, NC_NOWRITE,
-                     &(filenames.forcing[0].nc_id));
-    check_nc_status(status, "Error opening %s",
-                    filenames.forcing[0].nc_filename);
-    get_forcing_file_info(&param_set, 0);
-    if (param_set.N_TYPES[1] != 0) {
-        sprintf(filenames.forcing[1].nc_filename, "%s%4d.nc",
-                filenames.f_path_pfx[1], global_param.startyear);
-        status = nc_open(filenames.forcing[1].nc_filename, NC_NOWRITE,
-                         &(filenames.forcing[1].nc_id));
-        check_nc_status(status, "Error opening %s",
-                        filenames.forcing[1].nc_filename);
-        get_forcing_file_info(&param_set, 1);
-    }
+            get_forcing_file_info(&param_set, i);
 
-    if (param_set.N_TYPES[1] != 0 && global_param.forceyear[1] == 0) {
-        global_param.forceyear[1] = global_param.forceyear[0];
-        global_param.forcemonth[1] = global_param.forcemonth[0];
-        global_param.forceday[1] = global_param.forceday[0];
-        global_param.forcesec[1] = global_param.forcesec[0];
-        global_param.forceskip[1] = 0;
-        global_param.forceoffset[1] = global_param.forceskip[1];
-    }
-    if (param_set.force_steps_per_day[0] == 0) {
-        log_err("Forcing file time steps per day has not been "
-                "defined.  Make sure that the global file defines "
-                "FORCE_STEPS_PER_DAY.");
-    }
-    else {
-        param_set.FORCE_DT[0] = SEC_PER_DAY /
-                                (double) param_set.force_steps_per_day[0];
-    }
-    if (param_set.force_steps_per_day[1] > 0) {
-        param_set.FORCE_DT[1] = SEC_PER_DAY /
-                                (double) param_set.force_steps_per_day[1];
-    }
-    else {
-        param_set.FORCE_DT[1] = param_set.FORCE_DT[0];
+            if (param_set.force_steps_per_day[i] == 0) {
+                log_err("Forcing file time steps per day has not been "
+                        "defined.  Make sure that the global file defines "
+                        "FORCE_STEPS_PER_DAY.");
+            }
+            else {
+                param_set.FORCE_DT[i] = SEC_PER_DAY /
+                                        (double) param_set.force_steps_per_day[i];
+            }
+        }        
     }
 
     // Validate result directory

--- a/vic/src/vicwur/main_functions/display_current_settings.c
+++ b/vic/src/vicwur/main_functions/display_current_settings.c
@@ -36,7 +36,6 @@ void
 display_current_settings(int mode)
 {
     extern option_struct       options;
-    extern param_set_struct    param_set;
     extern global_param_struct global_param;
     extern filenames_struct    filenames;
 
@@ -294,7 +293,7 @@ display_current_settings(int mode)
     
     fprintf(LOG_DEST, "\n");
     fprintf(LOG_DEST, "Input Forcing Data:\n");
-    for (file_num = 0; file_num < 2; file_num++) {
+    for (file_num = 0; file_num < N_FORCING_TYPES; file_num++) {
         if (global_param.forceyear[file_num] > 0) {
             fprintf(LOG_DEST, "Forcing File %d:\t\t%s*\n", file_num + 1,
                     filenames.f_path_pfx[file_num]);
@@ -306,9 +305,6 @@ display_current_settings(int mode)
                     global_param.forceday[file_num]);
             fprintf(LOG_DEST, "FORCESEC\t\t%d\n",
                     global_param.forcesec[file_num]);
-            fprintf(LOG_DEST, "N_TYPES\t\t\t%zu\n",
-                    param_set.N_TYPES[file_num]);
-            fprintf(LOG_DEST, "FORCE_DT\t\t%f\n", param_set.FORCE_DT[file_num]);
         }
     }
 

--- a/vic/src/vicwur/main_functions/init_library.c
+++ b/vic/src/vicwur/main_functions/init_library.c
@@ -180,6 +180,7 @@ initialize_global_structures(void)
     mpi_decomposition = MPI_DECOMPOSITION_RANDOM;
     
     if (mpi_rank == VIC_MPI_ROOT) {
+        initialize_param_set();
         initialize_options();
         initialize_global();
         initialize_parameters();

--- a/vic/src/vicwur/main_functions/initialize_files.c
+++ b/vic/src/vicwur/main_functions/initialize_files.c
@@ -45,8 +45,9 @@ initialize_filenames()
     strcpy(filenames.domain.nc_filename, "MISSING");
     strcpy(filenames.result_dir, "MISSING");
     strcpy(filenames.log_path, "MISSING");
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < N_FORCING_TYPES; i++) {
         strcpy(filenames.f_path_pfx[i], "MISSING");
+        strcpy(filenames.forcing[i].nc_filename, "MISSING");
     }
     
     strcpy(filenames.groundwater.nc_filename, "MISSING");

--- a/vic/src/vicwur/main_functions/initialize_global.c
+++ b/vic/src/vicwur/main_functions/initialize_global.c
@@ -56,7 +56,7 @@ initialize_global()
     global_param.endday = 0;
     global_param.resolution = MISSING;
     global_param.wind_h = 10.0;
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < N_FORCING_TYPES; i++) {
         global_param.forceyear[i] = 0;
         global_param.forcemonth[i] = 1;
         global_param.forceday[i] = 1;

--- a/vic/src/vicwur/main_functions/initialize_param_set.c
+++ b/vic/src/vicwur/main_functions/initialize_param_set.c
@@ -1,0 +1,27 @@
+
+#include <vic.h>
+
+/******************************************************************************
+ * @brief    Initialize parameters structure.
+ *****************************************************************************/
+void
+initialize_param_set()
+{
+    extern param_set_struct param_set;
+    
+    size_t i;
+    
+    for(i = 0; i < N_FORCING_TYPES; i++){
+        param_set.FORCE_DT[i] = 0;
+        param_set.FORCE_ENDIAN[i] = 0;
+        param_set.FORCE_FORMAT[i] = BINARY;
+        param_set.FORCE_INDEX[i][0] = 0;
+        param_set.N_TYPES[i] = 0;
+        param_set.force_steps_per_day[i] = 0;
+        param_set.TYPE[i].N_ELEM = 0;
+        param_set.TYPE[i].SIGNED = false;
+        param_set.TYPE[i].SUPPLIED = false;
+        param_set.TYPE[i].multiplier = 0.0;
+        strcpy(param_set.TYPE[i].varname, "MISSING");
+    }
+}

--- a/vic/src/vicwur/main_functions/initialize_param_set.c
+++ b/vic/src/vicwur/main_functions/initialize_param_set.c
@@ -12,16 +12,8 @@ initialize_param_set()
     size_t i;
     
     for(i = 0; i < N_FORCING_TYPES; i++){
-        param_set.FORCE_DT[i] = 0;
-        param_set.FORCE_ENDIAN[i] = 0;
-        param_set.FORCE_FORMAT[i] = BINARY;
-        param_set.FORCE_INDEX[i][0] = 0;
-        param_set.N_TYPES[i] = 0;
         param_set.force_steps_per_day[i] = 0;
-        param_set.TYPE[i].N_ELEM = 0;
-        param_set.TYPE[i].SIGNED = false;
         param_set.TYPE[i].SUPPLIED = false;
-        param_set.TYPE[i].multiplier = 0.0;
         strcpy(param_set.TYPE[i].varname, "MISSING");
     }
 }

--- a/vic/src/vicwur/main_functions/make_dmy.c
+++ b/vic/src/vicwur/main_functions/make_dmy.c
@@ -85,7 +85,7 @@ make_dmy(global_param_struct *global)
     }
 
     /** Determine number of forcing records to skip before model start time **/
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < N_FORCING_TYPES; i++) {
         if (param_set.force_steps_per_day[i] != 0) {
             force_dmy.dayseconds = global->forcesec[i];
             force_dmy.year = global->forceyear[i];

--- a/vic/src/vicwur/main_functions/print_library_shared.c
+++ b/vic/src/vicwur/main_functions/print_library_shared.c
@@ -264,7 +264,7 @@ print_global_param(global_param_struct *gp)
     fprintf(LOG_DEST, "\tendday              : %hu\n", gp->endday);
     fprintf(LOG_DEST, "\tendmonth            : %hu\n", gp->endmonth);
     fprintf(LOG_DEST, "\tendyear             : %hu\n", gp->endyear);
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < N_FORCING_TYPES; i++) {
         fprintf(LOG_DEST, "\tforceday[%zd]        : %hu\n", i, gp->forceday[i]);
         fprintf(LOG_DEST, "\tforcesec[%zd]        : %u\n", i, gp->forcesec[i]);
         fprintf(LOG_DEST, "\tforcemonth[%zd]      : %hu\n", i,

--- a/vic/src/vicwur/main_functions/print_library_shared.c
+++ b/vic/src/vicwur/main_functions/print_library_shared.c
@@ -237,10 +237,8 @@ print_energy_bal(energy_bal_struct *eb,
 void
 print_force_type(force_type_struct *force_type)
 {
-    fprintf(LOG_DEST, "force_type:\n");
-    fprintf(LOG_DEST, "\tSIGNED    : %d\n", force_type->SIGNED);
+    fprintf(LOG_DEST, "force_type %s:\n", force_type->varname);
     fprintf(LOG_DEST, "\tSUPPLIED  : %d\n", force_type->SUPPLIED);
-    fprintf(LOG_DEST, "\tmultiplier: %f\n", force_type->multiplier);
 }
 
 /******************************************************************************
@@ -655,20 +653,9 @@ print_param_set(param_set_struct *param_set)
     fprintf(LOG_DEST, "param_set:\n");
     for (i = 0; i < N_FORCING_TYPES; i++) {
         print_force_type(&(param_set->TYPE[i]));
+        fprintf(LOG_DEST, "\force_steps_per_day : %zu\n", 
+                param_set->force_steps_per_day[i]);
     }
-    fprintf(LOG_DEST, "\tFORCE_DT    : %.4f %.4f\n", param_set->FORCE_DT[0],
-            param_set->FORCE_DT[1]);
-    fprintf(LOG_DEST, "\tFORCE_ENDIAN: %d %d\n", param_set->FORCE_ENDIAN[0],
-            param_set->FORCE_ENDIAN[1]);
-    fprintf(LOG_DEST, "\tFORCE_FORMAT: %d %d\n", param_set->FORCE_FORMAT[0],
-            param_set->FORCE_FORMAT[1]);
-    fprintf(LOG_DEST, "\tFORCE_INDEX :\n");
-    for (i = 0; i < N_FORCING_TYPES; i++) {
-        fprintf(LOG_DEST, "\t\t%zd: %d %d\n", i, param_set->FORCE_INDEX[0][i],
-                param_set->FORCE_INDEX[1][i]);
-    }
-    fprintf(LOG_DEST, "\tN_TYPES     : %zu %zu\n", param_set->N_TYPES[0],
-            param_set->N_TYPES[1]);
 }
 
 /******************************************************************************

--- a/vic/src/vicwur/main_functions/set_force_type.c
+++ b/vic/src/vicwur/main_functions/set_force_type.c
@@ -26,7 +26,7 @@
  *****************************************************************************/
 
 #include <vic.h>
-   
+
 /******************************************************************************
  * @brief    This routine determines the current forcing file data type and
  *           stores its location in the description of the current forcing file.
@@ -120,7 +120,7 @@ set_force_type(char *cmdstr)
         log_err("Undefined forcing variable TYPE %s",
                 optstr);
     }
-                
+
     if (strcasecmp("MISSING", ncvarname) == 0) {
         log_err("Must supply FORCING netCDF variable name for TYPE %s",
             optstr);
@@ -133,10 +133,8 @@ set_force_type(char *cmdstr)
         log_err("Tried to define FORCING for TYPE %s twice", 
                 optstr);
     }
-    
+
     strcpy(filenames.f_path_pfx[type], ncvarfile);
     strcpy(param_set.TYPE[type].varname, ncvarname);
     param_set.TYPE[type].SUPPLIED = true;
-    param_set.TYPE[type].N_ELEM = 1;
-    param_set.FORCE_FORMAT[type] = NETCDF4;
 }

--- a/vic/src/vicwur/main_functions/set_force_type.c
+++ b/vic/src/vicwur/main_functions/set_force_type.c
@@ -138,4 +138,5 @@ set_force_type(char *cmdstr)
     strcpy(param_set.TYPE[type].varname, ncvarname);
     param_set.TYPE[type].SUPPLIED = true;
     param_set.TYPE[type].N_ELEM = 1;
+    param_set.FORCE_FORMAT[type] = NETCDF4;
 }

--- a/vic/src/vicwur/main_functions/vic_force.c
+++ b/vic/src/vicwur/main_functions/vic_force.c
@@ -103,7 +103,6 @@ vic_force(void)
         if (current > 0 && (dmy[current].year != dmy[current - 1].year)) {
             global_param.forceoffset[f] = 0;
             global_param.forceskip[f] = 0;
-            
             // close the forcing file for the previous year and open the forcing
             // file for the current new year
             // (forcing file for the first year should already be open in
@@ -136,23 +135,19 @@ vic_force(void)
         d4count[1] = 1;
         d4count[2] = global_domain.n_ny;
         d4count[3] = global_domain.n_nx;
-    
+
         // read variables from file
         if(f == FCANOPY || f == ALBEDO || f == LAI) {
             for (j = 0; j < NF; j++) {
                 d4start[0] = global_param.forceskip[f] +
                              global_param.forceoffset[f] + j;
-                
                 for (v = 0; v < options.NVEGTYPES; v++) {
                     d4start[1] = v;
-                    
                     get_scatter_nc_field_double(&(filenames.forcing[f]),
                                                  param_set.TYPE[f].varname, 
                                                  d4start, d4count,dvar);
-                    
                     for (i = 0; i < local_domain.ncells_active; i++) {
                         vidx = veg_con_map[i].vidx[v];
-                        
                         if (vidx != NODATA_VEG) {
                             if(options.FCAN_SRC == FROM_VEGHIST && f == FCANOPY){                                
                                 veg_hist[i][vidx].fcanopy[j] = (double) dvar[i];

--- a/vic/src/vicwur/main_functions/vic_force.c
+++ b/vic/src/vicwur/main_functions/vic_force.c
@@ -55,6 +55,7 @@ vic_force(void)
     size_t                     i;
     size_t                     j;
     size_t                     v;
+    size_t                     f;
     size_t                     band;
     int                        vidx;
     int                        status;
@@ -71,145 +72,125 @@ vic_force(void)
     // global_param.forceoffset[0] resets every year since the met file restarts
     // every year
     // global_param.forceskip[0] should also reset to 0 after the first year
-    if (current > 0 && (dmy[current].year != dmy[current - 1].year)) {
-        global_param.forceoffset[0] = 0;
-        global_param.forceskip[0] = 0;
-        // close the forcing file for the previous year and open the forcing
-        // file for the current new year
-        // (forcing file for the first year should already be open in
-        // get_global_param)
-        if (mpi_rank == VIC_MPI_ROOT) {
-            // close previous forcing file
-            status = nc_close(filenames.forcing[0].nc_id);
-            check_nc_status(status, "Error closing %s",
-                            filenames.forcing[0].nc_filename);
-            // open new forcing file
-            sprintf(filenames.forcing[0].nc_filename, "%s%4d.nc",
-                    filenames.f_path_pfx[0], dmy[current].year);
-            status = nc_open(filenames.forcing[0].nc_filename, NC_NOWRITE,
-                             &(filenames.forcing[0].nc_id));
-            check_nc_status(status, "Error opening %s",
-                            filenames.forcing[0].nc_filename);
+    for(f = 0; f < N_FORCING_TYPES; f++){
+        if(!param_set.TYPE[f].SUPPLIED){
+            continue;
         }
-    }
-
-    // only the time slice changes for the met file reads. The rest is constant
-    d3start[1] = 0;
-    d3start[2] = 0;
-    d3count[0] = 1;
-    d3count[1] = global_domain.n_ny;
-    d3count[2] = global_domain.n_nx;
-
-    // Air temperature: tas
-    for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
-                     j;
-        get_scatter_nc_field_double(&(filenames.forcing[0]),
-                                    param_set.TYPE[AIR_TEMP].varname,
-                                    d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells_active; i++) {
-            force[i].air_temp[j] = (double) dvar[i];
+        
+        if (current > 0 && (dmy[current].year != dmy[current - 1].year)) {
+            global_param.forceoffset[f] = 0;
+            global_param.forceskip[f] = 0;
+            
+            // close the forcing file for the previous year and open the forcing
+            // file for the current new year
+            // (forcing file for the first year should already be open in
+            // get_global_param)
+            if (mpi_rank == VIC_MPI_ROOT) {
+                // close previous forcing file
+                status = nc_close(filenames.forcing[f].nc_id);
+                check_nc_status(status, "Error closing %s",
+                                filenames.forcing[f].nc_filename);
+                // open new forcing file
+                sprintf(filenames.forcing[f].nc_filename, "%s%4d.nc",
+                        filenames.f_path_pfx[f], dmy[current].year);
+                status = nc_open(filenames.forcing[f].nc_filename, NC_NOWRITE,
+                                 &(filenames.forcing[f].nc_id));
+                check_nc_status(status, "Error opening %s",
+                                filenames.forcing[f].nc_filename);
+            }
         }
-    }
 
-    // Precipitation: prcp
-    for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
-                     j;
-        get_scatter_nc_field_double(&(filenames.forcing[0]),
-                                    param_set.TYPE[PREC].varname,
-                                    d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells_active; i++) {
-            force[i].prec[j] = (double) dvar[i];
-        }
-    }
-
-    // Downward solar radiation: dswrf
-    for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
-                     j;
-        get_scatter_nc_field_double(&(filenames.forcing[0]),
-                                    param_set.TYPE[SWDOWN].varname,
-                                    d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells_active; i++) {
-            force[i].shortwave[j] = (double) dvar[i];
-        }
-    }
-
-    // Downward longwave radiation: dlwrf
-    for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
-                     j;
-        get_scatter_nc_field_double(&(filenames.forcing[0]),
-                                    param_set.TYPE[LWDOWN].varname,
-                                    d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells_active; i++) {
-            force[i].longwave[j] = (double) dvar[i];
-        }
-    }
-
-    // Wind speed: wind
-    for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
-                     j;
-        get_scatter_nc_field_double(&(filenames.forcing[0]),
-                                    param_set.TYPE[WIND].varname,
-                                    d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells_active; i++) {
-            force[i].wind[j] = (double) dvar[i];
-        }
-    }
-
-    // vapor pressure: vp
-    for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
-                     j;
-        get_scatter_nc_field_double(&(filenames.forcing[0]),
-                                    param_set.TYPE[VP].varname,
-                                    d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells_active; i++) {
-            force[i].vp[j] = (double) dvar[i];
-        }
-    }
-
-    // Pressure: pressure
-    for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
-                     j;
-        get_scatter_nc_field_double(&(filenames.forcing[0]),
-                                    param_set.TYPE[PRESSURE].varname,
-                                    d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells_active; i++) {
-            force[i].pressure[j] = (double) dvar[i];
-        }
-    }
-    // Optional inputs
-    if (options.LAKES) {
-        // Channel inflow to lake
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
-                     j;
-        get_scatter_nc_field_double(&(filenames.forcing[0]),
-                                    param_set.TYPE[CHANNEL_IN].varname,
-                                    d3start, d3count, dvar);
+        // only the time slice changes for the met file reads. The rest is constant
+        d3start[1] = 0;
+        d3start[2] = 0;
+        d3count[0] = 1;
+        d3count[1] = global_domain.n_ny;
+        d3count[2] = global_domain.n_nx;
+        
+        d4start[2] = 0;
+        d4start[3] = 0;
+        d4count[0] = 1;
+        d4count[1] = 1;
+        d4count[2] = global_domain.n_ny;
+        d4count[3] = global_domain.n_nx;
+    
+        // read variables from file
         for (j = 0; j < NF; j++) {
-            for (i = 0; i < local_domain.ncells_active; i++) {
-                force[i].channel_in[j] = (double) dvar[i];
+            if(f == FCANOPY || f == ALBEDO || f == LAI) {
+                d4start[0] = global_param.forceskip[1] +
+                             global_param.forceoffset[1] + j;
+                
+                for (v = 0; v < options.NVEGTYPES; v++) {
+                    d4start[1] = v;
+                    
+                    get_scatter_nc_field_double(&(filenames.forcing[f]),
+                                                 param_set.TYPE[f].varname, 
+                                                 d4start, d4count,dvar);
+                    
+                    for (i = 0; i < local_domain.ncells_active; i++) {
+                        vidx = veg_con_map[i].vidx[v];
+                        if (vidx != NODATA_VEG) {
+                            if(options.FCAN_SRC == FROM_VEGHIST && f == FCANOPY){                                
+                                veg_hist[i][vidx].fcanopy[j] = (double) dvar[i];
+                            } else if(options.ALB_SRC == FROM_VEGHIST && f == ALBEDO){                                
+                                veg_hist[i][vidx].albedo[j] = (double) dvar[i];
+                            } else if(options.LAI_SRC == FROM_VEGHIST && f == LAI){                                
+                                veg_hist[i][vidx].LAI[j] = (double) dvar[i];
+                            }
+                        }
+                    }
+                }                
+            } else {
+                d3start[0] = global_param.forceskip[f] + global_param.forceoffset[f] +
+                             j;
+                
+                get_scatter_nc_field_double(&(filenames.forcing[f]),
+                                            param_set.TYPE[f].varname,
+                                            d3start, d3count, dvar);
+
+                for (i = 0; i < local_domain.ncells_active; i++) {
+                    if(f == AIR_TEMP){
+                        force[i].air_temp[j] = (double) dvar[i];
+                    }else if (f == PREC){
+                        force[i].prec[j] = (double) dvar[i];
+                    }else if (f == SWDOWN){
+                        force[i].shortwave[j] = (double) dvar[i];
+                    }else if (f == LWDOWN){
+                        force[i].longwave[j] = (double) dvar[i];
+                    }else if (f == WIND){
+                        force[i].wind[j] = (double) dvar[i];
+                    }else if (f == VP){
+                        force[i].vp[j] = (double) dvar[i];
+                    }else if (f == PRESSURE){
+                        force[i].pressure[j] = (double) dvar[i];
+                    } else if (options.LAKES && f == CHANNEL_IN) {
+                        force[i].channel_in[j] = (double) dvar[i];
+                    } else if (options.CARBON && f == CATM) {
+                        force[i].Catm[j] = (double) dvar[i];
+                    } else if (options.CARBON && f == FDIR) {
+                        force[i].fdir[j] = (double) dvar[i];
+                    } else if (options.CARBON && f == PAR) {
+                        force[i].par[j] = (double) dvar[i];
+                    }
+                }
+            }
+        }
+        
+        // Update the offset counter
+        global_param.forceoffset[f] += NF;  
+        
+        if (current == global_param.nrecs - 1) { 
+            // Close forcing file if it is the last time step  
+            if (mpi_rank == VIC_MPI_ROOT) {
+                status = nc_close(filenames.forcing[f].nc_id);
+                check_nc_status(status, "Error closing %s",
+                                filenames.forcing[f].nc_filename);
             }
         }
     }
-    if (options.CARBON) {
-        // Atmospheric CO2 mixing ratio
-        for (j = 0; j < NF; j++) {
-            d3start[0] = global_param.forceskip[0] +
-                         global_param.forceoffset[0] + j;
-            get_scatter_nc_field_double(&(filenames.forcing[0]),
-                                        param_set.TYPE[CATM].varname,
-                                        d3start, d3count, dvar);
-            for (i = 0; i < local_domain.ncells_active; i++) {
-                force[i].Catm[j] = (double) dvar[i];
-            }
-        }
-        // Cosine of solar zenith angle
+    
+    // calculate derived variables
+    if (options.CARBON){
         for (j = 0; j < NF; j++) {
             for (i = 0; i < local_domain.ncells_active; i++) {
                 force[i].coszen[j] = compute_coszen(
@@ -219,41 +200,7 @@ vic_force(void)
                     dmy[current].dayseconds);
             }
         }
-        // Fraction of shortwave that is direct
-        for (j = 0; j < NF; j++) {
-            d3start[0] = global_param.forceskip[0] +
-                         global_param.forceoffset[0] + j;
-            get_scatter_nc_field_double(&(filenames.forcing[0]),
-                                        param_set.TYPE[FDIR].varname,
-                                        d3start, d3count, dvar);
-            for (i = 0; i < local_domain.ncells_active; i++) {
-                force[i].fdir[j] = (double) dvar[i];
-            }
-        }
-        // Photosynthetically active radiation
-        for (j = 0; j < NF; j++) {
-            d3start[0] = global_param.forceskip[0] +
-                         global_param.forceoffset[0] + j;
-            get_scatter_nc_field_double(&(filenames.forcing[0]),
-                                        param_set.TYPE[PAR].varname,
-                                        d3start, d3count, dvar);
-            for (i = 0; i < local_domain.ncells_active; i++) {
-                force[i].par[j] = (double) dvar[i];
-            }
-        }
     }
-
-    if (mpi_rank == VIC_MPI_ROOT) {
-        // Close forcing file if it is the last time step
-        if (current == global_param.nrecs - 1) {
-            status = nc_close(filenames.forcing[0].nc_id);
-            check_nc_status(status, "Error closing %s",
-                            filenames.forcing[0].nc_filename);
-        }
-    }
-
-    // Update the offset counter
-    global_param.forceoffset[0] += NF;
 
     // Initialize the veg_hist structure with the current climatological
     // vegetation parameters.  This may be overwritten with the historical
@@ -277,117 +224,6 @@ vic_force(void)
             }
         }
     }
-
-    // Read veg_hist file
-    if (options.LAI_SRC == FROM_VEGHIST ||
-        options.FCAN_SRC == FROM_VEGHIST ||
-        options.ALB_SRC == FROM_VEGHIST) {
-        // global_param.forceoffset[1] resets every year since the met file restarts
-        // every year
-        // global_param.forceskip[1] should also reset to 0 after the first year
-        if (current > 0 && (dmy[current].year != dmy[current - 1].year)) {
-            global_param.forceoffset[1] = 0;
-            global_param.forceskip[1] = 0;
-            // close the forcing file for the previous year and open the forcing
-            // file for the current new year
-            // (forcing file for the first year should already be open in
-            // get_global_param)
-            if (mpi_rank == VIC_MPI_ROOT) {
-                // close previous forcing file
-                status = nc_close(filenames.forcing[1].nc_id);
-                check_nc_status(status, "Error closing %s",
-                                filenames.forcing[1].nc_filename);
-                // open new forcing file
-                sprintf(filenames.forcing[1].nc_filename, "%s%4d.nc",
-                        filenames.f_path_pfx[1],
-                        dmy[current].year);
-                status = nc_open(filenames.forcing[1].nc_filename, NC_NOWRITE,
-                                 &(filenames.forcing[1].nc_id));
-                check_nc_status(status, "Error opening %s",
-                                filenames.forcing[1].nc_filename);
-            }
-        }
-
-        // only the time slice changes for the met file reads. The rest is constant
-        d4start[2] = 0;
-        d4start[3] = 0;
-        d4count[0] = 1;
-        d4count[1] = 1;
-        d4count[2] = global_domain.n_ny;
-        d4count[3] = global_domain.n_nx;
-
-        // Leaf Area Index: LAI
-        if (options.LAI_SRC == FROM_VEGHIST) {
-            for (j = 0; j < NF; j++) {
-                d4start[0] = global_param.forceskip[1] +
-                             global_param.forceoffset[1] + j;
-                for (v = 0; v < options.NVEGTYPES; v++) {
-                    d4start[1] = v;
-                    get_scatter_nc_field_double(&(filenames.forcing[1]), "LAI",
-                                                d4start, d4count, dvar);
-                    for (i = 0; i < local_domain.ncells_active; i++) {
-                        vidx = veg_con_map[i].vidx[v];
-                        if (vidx != NODATA_VEG) {
-                            veg_hist[i][vidx].LAI[j] = (double) dvar[i];
-                        }
-                    }
-                }
-            }
-        }
-
-        // Partial veg cover fraction: fcanopy
-        if (options.FCAN_SRC == FROM_VEGHIST) {
-            for (j = 0; j < NF; j++) {
-                d4start[0] = global_param.forceskip[1] +
-                             global_param.forceoffset[1] + j;
-                for (v = 0; v < options.NVEGTYPES; v++) {
-                    d4start[1] = v;
-                    get_scatter_nc_field_double(&(filenames.forcing[1]),
-                                                "fcanopy", d4start, d4count,
-                                                dvar);
-                    for (i = 0; i < local_domain.ncells_active; i++) {
-                        vidx = veg_con_map[i].vidx[v];
-                        if (vidx != NODATA_VEG) {
-                            veg_hist[i][vidx].fcanopy[j] = (double) dvar[i];
-                        }
-                    }
-                }
-            }
-        }
-
-        // Albedo: albedo
-        if (options.ALB_SRC == FROM_VEGHIST) {
-            for (j = 0; j < NF; j++) {
-                d4start[0] = global_param.forceskip[1] +
-                             global_param.forceoffset[1] + j;
-                for (v = 0; v < options.NVEGTYPES; v++) {
-                    d4start[1] = v;
-                    get_scatter_nc_field_double(&(filenames.forcing[1]),
-                                                "albedo", d4start, d4count,
-                                                dvar);
-                    for (i = 0; i < local_domain.ncells_active; i++) {
-                        vidx = veg_con_map[i].vidx[v];
-                        if (vidx != NODATA_VEG) {
-                            veg_hist[i][vidx].albedo[j] = (double) dvar[i];
-                        }
-                    }
-                }
-            }
-        }
-
-        if (mpi_rank == VIC_MPI_ROOT) {
-            // Close forcing file if it is the last time step
-            if (current == global_param.nrecs - 1) {
-                status = nc_close(filenames.forcing[1].nc_id);
-                check_nc_status(status, "Error closing %s",
-                                filenames.forcing[1].nc_filename);
-            }
-        }
-
-        // Update the offset counter
-        global_param.forceoffset[1] += NF;
-    }
-
 
     // allocate memory for t_offset
     t_offset = malloc(local_domain.ncells_active * sizeof(*t_offset));

--- a/vic/src/vicwur/main_functions/vic_mpi_support.c
+++ b/vic/src/vicwur/main_functions/vic_mpi_support.c
@@ -173,32 +173,32 @@ create_MPI_global_struct_type(MPI_Datatype *mpi_type)
 
     // unsigned short forceday[2];
     offsets[i] = offsetof(global_param_struct, forceday);
-    blocklengths[i] = 2;
+    blocklengths[i] = N_FORCING_TYPES;
     mpi_types[i++] = MPI_UNSIGNED_SHORT;
 
     // unsigned int forcesec[2];
     offsets[i] = offsetof(global_param_struct, forcesec);
-    blocklengths[i] = 2;
+    blocklengths[i] = N_FORCING_TYPES;
     mpi_types[i++] = MPI_UNSIGNED;
 
     // unsigned short forcemonth[2];
     offsets[i] = offsetof(global_param_struct, forcemonth);
-    blocklengths[i] = 2;
+    blocklengths[i] = N_FORCING_TYPES;
     mpi_types[i++] = MPI_UNSIGNED_SHORT;
 
     // unsigned short forceoffset[2];
     offsets[i] = offsetof(global_param_struct, forceoffset);
-    blocklengths[i] = 2;
+    blocklengths[i] = N_FORCING_TYPES;
     mpi_types[i++] = MPI_UNSIGNED_SHORT;
 
     // unsigned int forceskip[2];
     offsets[i] = offsetof(global_param_struct, forceskip);
-    blocklengths[i] = 2;
+    blocklengths[i] = N_FORCING_TYPES;
     mpi_types[i++] = MPI_UNSIGNED;
 
     // unsigned short int forceyear[2];
     offsets[i] = offsetof(global_param_struct, forceyear);
-    blocklengths[i] = 2;
+    blocklengths[i] = N_FORCING_TYPES;
     mpi_types[i++] = MPI_UNSIGNED_SHORT;
 
     // size_t nrecs;

--- a/vic/src/vicwur/main_functions/vic_mpi_support.c
+++ b/vic/src/vicwur/main_functions/vic_mpi_support.c
@@ -293,7 +293,7 @@ create_MPI_filenames_struct_type(MPI_Datatype *mpi_type)
     MPI_Datatype   *mpi_types;
 
     // nitems has to equal the number of elements in filenames_struct
-    nitems = 11;
+    nitems = 7;
     blocklengths = malloc(nitems * sizeof(*blocklengths));
     check_alloc_status(blocklengths, "Memory allocation error.");
 
@@ -312,34 +312,17 @@ create_MPI_filenames_struct_type(MPI_Datatype *mpi_type)
     // reset i
     i = 0;
 
-    // char forcing[2][MAXSTRING];
-    offsets[i] = offsetof(filenames_struct, forcing);
-    blocklengths[i] *= 2;
-    mpi_types[i++] = MPI_CHAR;
-
-    // char f_path_pfx[2][MAXSTRING];
+    // char met_forcing_pfx[MAX_FORCE_FILES][MAXSTRING];
     offsets[i] = offsetof(filenames_struct, f_path_pfx);
-    blocklengths[i] *= 2;
+    blocklengths[i] *= N_FORCING_TYPES;
     mpi_types[i++] = MPI_CHAR;
 
     // char global[MAXSTRING];
     offsets[i] = offsetof(filenames_struct, global);
     mpi_types[i++] = MPI_CHAR;
 
-    // char domain[MAXSTRING];
-    offsets[i] = offsetof(filenames_struct, domain);
-    mpi_types[i++] = MPI_CHAR;
-
     // char constants[MAXSTRING];
     offsets[i] = offsetof(filenames_struct, constants);
-    mpi_types[i++] = MPI_CHAR;
-
-    // char init_state[MAXSTRING];
-    offsets[i] = offsetof(filenames_struct, init_state);
-    mpi_types[i++] = MPI_CHAR;
-
-    // char params[MAXSTRING];
-    offsets[i] = offsetof(filenames_struct, params);
     mpi_types[i++] = MPI_CHAR;
 
     // char result_dir[MAXSTRING];
@@ -354,8 +337,8 @@ create_MPI_filenames_struct_type(MPI_Datatype *mpi_type)
     offsets[i] = offsetof(filenames_struct, log_path);
     mpi_types[i++] = MPI_CHAR;
 
-    // char log_path[MAXSTRING];
-    offsets[i] = offsetof(filenames_struct, routing);
+    // char water_use_forcing_pfx[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, water_use_forcing_pfx);
     mpi_types[i++] = MPI_CHAR;
 
     // make sure that the we have the right number of elements


### PR DESCRIPTION
Change the **forcing input file system** to allow a different forcing files per forcing variable. Also the second forcing file previously implemented in VIC is removed since these forcing variables can now be given a new forcing file.

Forcing in the global parameter file should now be specified as follows:
-> # FORCE_TYPE	TYPE			VARIABLE NAME		FILE
-> FORCE_TYPE    	AIR_TEMP		tas					forcing/filename.
If necessary forcing files are not given, vic will exit with an error. Forcing is read in per file in vic_force.

There are still redundant structures and variables allocated to do with the old forcing file system (specifically param_set_struct and force_type_struct), which can be removed in the future