### PR TITLE
Valgrind issues resolved

### DIFF
--- a/vic/src/plugins/dams/dam_run.c
+++ b/vic/src/plugins/dams/dam_run.c
@@ -374,14 +374,12 @@ dam_run(size_t cur_cell)
             }
 
             // Shift array
-            cshift(dam_var[cur_cell][i].history_flow, 1, DAM_HIST_YEARS *
-                   MONTHS_PER_YEAR, 1,
-                   -1);
-            cshift(dam_var[cur_cell][i].history_demand, 1, DAM_HIST_YEARS *
-                   MONTHS_PER_YEAR, 1,
-                   -1);
-            cshift(dam_var[cur_cell][i].op_discharge, 1, MONTHS_PER_YEAR, 1, 1);
-            cshift(dam_var[cur_cell][i].op_volume, 1, MONTHS_PER_YEAR, 1, 1);
+            cshift(dam_var[cur_cell][i].history_flow, DAM_HIST_YEARS *
+                   MONTHS_PER_YEAR, 1, 0, -1);
+            cshift(dam_var[cur_cell][i].history_demand, DAM_HIST_YEARS *
+                   MONTHS_PER_YEAR, 1, 0, -1);
+            cshift(dam_var[cur_cell][i].op_discharge, MONTHS_PER_YEAR, 1, 0, 1);
+            cshift(dam_var[cur_cell][i].op_volume, MONTHS_PER_YEAR, 1, 0, 1);
         }
 
         dam_var[cur_cell][i].total_flow +=

--- a/vic/src/plugins/efr/efr_run.c
+++ b/vic/src/plugins/efr/efr_run.c
@@ -54,9 +54,8 @@ efr_run(size_t cur_cell)
         // Shift array
         efr_var[cur_cell].history_flow[EFR_HIST_YEARS * MONTHS_PER_YEAR -
                                        1] = 0.0;
-        cshift(efr_var[cur_cell].history_flow, 1, EFR_HIST_YEARS *
-               MONTHS_PER_YEAR, 1,
-               -1);
+        cshift(efr_var[cur_cell].history_flow, EFR_HIST_YEARS *
+               MONTHS_PER_YEAR, 1, 0, -1);
 
         // Store monthly average
         efr_var[cur_cell].history_flow[0] =

--- a/vic/src/plugins/ext_mpi/ext_mpi_support.c
+++ b/vic/src/plugins/ext_mpi/ext_mpi_support.c
@@ -525,7 +525,7 @@ mpi_map_decomp_domain_basin(size_t   ncells,
     free(basin_to_node);
     
     for(i = 0; i < basins.Nbasin; i++){
-        free(basins.catchment);
+        free(basins.catchment[i]);
     }
     free(basins.Ncells);
     free(basins.basin_map);

--- a/vic/src/plugins/ext_mpi/ext_mpi_support.c
+++ b/vic/src/plugins/ext_mpi/ext_mpi_support.c
@@ -520,6 +520,17 @@ mpi_map_decomp_domain_basin(size_t   ncells,
             }
         }
     }
+    
+    free(node_ids);
+    free(basin_to_node);
+    
+    for(i = 0; i < basins.Nbasin; i++){
+        free(basins.catchment);
+    }
+    free(basins.Ncells);
+    free(basins.basin_map);
+    free(basins.catchment);
+    free(basins.sorted_basins);
 }
 
 void
@@ -607,4 +618,15 @@ mpi_map_decomp_domain_file(size_t   ncells,
             }
         }
     }
+    
+    free(node_ids);
+    free(basin_to_node);
+    
+    for(i = 0; i < basins.Nbasin; i++){
+        free(basins.catchment[i]);
+    }
+    free(basins.Ncells);
+    free(basins.basin_map);
+    free(basins.catchment);
+    free(basins.sorted_basins);
 }

--- a/vic/src/plugins/routing/rout_run.c
+++ b/vic/src/plugins/routing/rout_run.c
@@ -41,8 +41,8 @@ rout_gl_run()
     for (i = 0; i < local_domain.ncells_active; i++) {
         rout_var[i].discharge[0] = 0.0;
         rout_var[i].nat_discharge[0] = 0.0;
-        cshift(rout_var[i].discharge, 1, options.RIRF_NSTEPS, 1, 1);
-        cshift(rout_var[i].nat_discharge, 1, options.RIRF_NSTEPS, 1, 1);
+        cshift(rout_var[i].discharge, options.RIRF_NSTEPS, 1, 0, 1);
+        cshift(rout_var[i].nat_discharge, options.RIRF_NSTEPS, 1, 0, 1);
     }
 
     // Alloc
@@ -254,8 +254,8 @@ rout_run(size_t cur_cell)
 
     rout_var[cur_cell].discharge[0] = 0.0;
     rout_var[cur_cell].nat_discharge[0] = 0.0;
-    cshift(rout_var[cur_cell].discharge, 1, options.RIRF_NSTEPS, 1, 1);
-    cshift(rout_var[cur_cell].nat_discharge, 1, options.RIRF_NSTEPS, 1, 1);
+    cshift(rout_var[cur_cell].discharge, options.RIRF_NSTEPS, 1, 0, 1);
+    cshift(rout_var[cur_cell].nat_discharge, options.RIRF_NSTEPS, 1, 0, 1);
 
     inflow = 0;
     for (i = 0; i < rout_con[cur_cell].Nupstream; i++) {

--- a/vic/src/support/ext_get_nc_field.c
+++ b/vic/src/support/ext_get_nc_field.c
@@ -28,6 +28,8 @@ get_active_nc_field_double(nameid_struct *nc_nameid,
     map(sizeof(double), global_domain.ncells_active, filter_active_cells, NULL,
         dvar, var);
 
+    free(dvar);
+
     return status;
 }
 
@@ -58,6 +60,8 @@ get_active_nc_field_float(nameid_struct *nc_nameid,
     // filter the active cells only
     map(sizeof(float), global_domain.ncells_active, filter_active_cells, NULL,
         fvar, var);
+
+    free(fvar);
 
     return status;
 }
@@ -91,5 +95,7 @@ get_active_nc_field_int(nameid_struct *nc_nameid,
         NULL,
         ivar, var);
 
+    free(ivar);
+    
     return status;
 }

--- a/vic/src/vic_image_run.c
+++ b/vic/src/vic_image_run.c
@@ -49,7 +49,7 @@ vic_image_run(dmy_struct *dmy_current)
     extern veg_hist_struct   **veg_hist;
     extern veg_lib_struct    **veg_lib;
     extern int                 mpi_rank;
-    char                       dmy_str[MAXSTRING];
+    char                       vic_run_ref_str[MAXSTRING];
     size_t                     i;
     size_t                     cur_cell;
     timer_struct               timer;
@@ -68,8 +68,8 @@ vic_image_run(dmy_struct *dmy_current)
     #pragma omp parallel for default(shared) private(i, timer, vic_run_ref_str)
     for (i = 0; i < local_domain.ncells_active; i++) {
         // Set global reference string (for debugging inside vic_run)
-        sprintf(vic_run_ref_str, "Gridcell io_idx: %zu, timestep info: %s",
-                local_domain.locations[i].io_idx, dmy_str);
+        sprintf(vic_run_ref_str, "Gridcell io_idx: %zu, timestep: %zu",
+                local_domain.locations[i].io_idx, current);
 
         update_step_vars(&(all_vars[i]), veg_con[i], veg_hist[i]);
 

--- a/vic/src/vic_main.c
+++ b/vic/src/vic_main.c
@@ -134,7 +134,11 @@ main(int    argc,
     timer_stop(&(global_timers[TIMER_VIC_INIT]));
     // start vic run timer
     timer_start(&(global_timers[TIMER_VIC_RUN]));
-
+    // initialize vic force timer
+    timer_init(&(global_timers[TIMER_VIC_FORCE]));
+    // initialize vic write timer
+    timer_init(&(global_timers[TIMER_VIC_WRITE]));
+    
     // loop over all timesteps
     for (current = 0; current < global_param.nrecs; current++) {
         // read forcing data


### PR DESCRIPTION
**Resolves several issues that came to light using valgrind.**

Most of the issues had to do with my plugins (such as the wrong use of the **cshift** function, not properly freeing everything to do with the **mpi decomposition** and not properly freeing everything to do with the **get_active_nc_field_X** functions).

However VIC itself also displayed some issues to do with not instantiating the **timers** for the forcing and writing, and not filling the **dmy_str** used for the run reference string.

There are still some issues with the **filenames.forcing** structure and the omp parallel computation, these still need to be resolved.