### PR TITLE
Changed several warnings in VIC

### DIFF
--- a/vic/src/vic_main.c
+++ b/vic/src/vic_main.c
@@ -93,10 +93,7 @@ main(int    argc,
 
     // Initialize MPI - note: logging not yet initialized
     status = MPI_Init(&argc, &argv);
-    if (status != MPI_SUCCESS) {
-        fprintf(stderr, "MPI error in main(): %d\n", status);
-        exit(EXIT_FAILURE);
-    }
+    check_mpi_status(status, "MPI error.");
 
     // Initialize Log Destination
     initialize_log();
@@ -125,11 +122,13 @@ main(int    argc,
     vic_init_output(&(dmy[0]));
 
     // Initialization is complete, print settings
-    log_info(
-        "Initialization is complete, print global param, parameters and options structures");
-    print_global_param(&global_param);
-    print_option(&options);
-    print_parameters(&param);
+    if (mpi_rank == VIC_MPI_ROOT) {
+        log_info(
+            "Initialization is complete; print global param, parameters and options structures");
+        print_global_param(&global_param);
+        print_option(&options);
+        print_parameters(&param);
+    }
 
     // stop init timer
     timer_stop(&(global_timers[TIMER_VIC_INIT]));
@@ -160,9 +159,7 @@ main(int    argc,
 
         // Write state file
         if (check_save_state_flag(current, &dmy_state)) {
-            debug("writing state file for timestep %zu", current);
             vic_store(&dmy_state, state_filename);
-            debug("finished storing state file: %s", state_filename)
         }
     }
     // stop vic run timer
@@ -175,9 +172,7 @@ main(int    argc,
 
     // finalize MPI
     status = MPI_Finalize();
-    if (status != MPI_SUCCESS) {
-        log_err("MPI error: %d", status);
-    }
+    check_mpi_status(status, "MPI error.");
 
     log_info("Completed running VIC %s", VIC_DRIVER);
 

--- a/vic/src/vic_start.c
+++ b/vic/src/vic_start.c
@@ -147,11 +147,11 @@ vic_start(void)
 
         for (i = 0; i < (size_t)mpi_size; i++) {
             log_info(
-                "Mpi decomposition node %zu: %d - %d (%.3f) [offset - size (fraction of total)]",
-                i, mpi_map_global_array_offsets[i],
+                "Mpi decomposition size %d (%.3f) [node %zu]",
                 mpi_map_local_array_sizes[i],
                 ((float)mpi_map_local_array_sizes[i] /
-                      (float)global_domain.ncells_active));
+                      (float)global_domain.ncells_active),
+                i);
         }
         for (i = 0; i < (size_t)mpi_size; i++) {
             if (mpi_map_local_array_sizes[i] <= 0) {

--- a/vic/src/vicwur/main_functions/vic_log.c
+++ b/vic/src/vicwur/main_functions/vic_log.c
@@ -127,7 +127,7 @@ setup_logging(int    id,
         *logfile = open_file(logfilename, "w");
 
         // Print log file name to stderr
-        log_info("Initialized Log File: %s", logfilename);
+        log_info("Initialized Log File: %s [ID %d]", logfilename, id);
 
         // Set Log Destination
         LOG_DEST = *logfile;
@@ -136,7 +136,7 @@ setup_logging(int    id,
         log_info("Initialized Log File: %s", logfilename);
     }
     else {
-        log_info("Logging to stderr");
+        log_info("Logging to stderr [ID %d]", id);
     }
 }
 


### PR DESCRIPTION
Changed some of the warning to either **reflect VIC development** or be **less intrusive** in the log.

- Warnings that fire on each node now contain the node id
- Mpi checks are now done using built-in functions
- Initialization validation now displays gross totals over the domain instead of firing on each individual location (heavily reducing the log size for global runs)