### PR TITLE
Changed vic_run_veg_lib to veg_lib, removed vic_run_veg_lib

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 GNU GENERAL PUBLIC LICENSE
-                       Version 2, June 1991
+                        Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 GNU GENERAL PUBLIC LICENSE
-                        Version 2, June 1991
+                       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA

--- a/vic/vic_run/include/vic_run.h
+++ b/vic/vic_run/include/vic_run.h
@@ -80,11 +80,11 @@ double calc_surf_energy_bal(double, double, double, double, double, double,
                             double *, double *, double *, double *, double *,
                             double, double *, double *, double, double *,
                             double *, int, int, size_t, size_t, double, size_t,
-                            unsigned short int, int, unsigned short int,
+                            unsigned short int, int,
                             double *, double *, force_data_struct *,
                             dmy_struct *, energy_bal_struct *,
                             layer_data_struct *, snow_data_struct *,
-                            soil_con_struct *, veg_var_struct *);
+                            soil_con_struct *, veg_var_struct *, veg_lib_struct *);
 double calc_veg_displacement(double);
 double calc_veg_height(double);
 double calc_veg_roughness(double);
@@ -103,8 +103,8 @@ void canopy_assimilation(char, double, double, double, double *, double, double,
                          double *, double, double, double *, double, char *,
                          double *, double *, double *, double *, double *,
                          double *, double *, double *, double *, double *);
-double canopy_evap(layer_data_struct *, veg_var_struct *, bool,
-                   unsigned short int, double *, double, double, double, double,
+double canopy_evap(layer_data_struct *, veg_var_struct *, veg_lib_struct *, bool,
+                   double *, double, double, double, double,
                    double, double, double, double, double *, double *, double *,
                    double *, double *, double *, double, double, double *);
 void colavg(double *, double *, double *, double, double *, int, double,
@@ -244,9 +244,9 @@ int snow_intercept(double, double, double, double, double, double, double,
                    double *, double *, double *, double *, double *, double *,
                    double *, bool *, unsigned int *, double *, double *,
                    double *, double *, double *, double *, double *, int, int,
-                   int, int, int, unsigned short int, double *, double *,
+                   int, int, int, double *, double *,
                    force_data_struct *, layer_data_struct *, soil_con_struct *,
-                   veg_var_struct *);
+                   veg_var_struct *, veg_lib_struct *);
 int snow_melt(double, double, double, double, double *, double, double *,
               double, double, double, double, double, double, double, double,
               double, double, double, double, double, double *, double *,
@@ -272,9 +272,9 @@ double solve_snow(char, double, double, double, double, double, double, double,
                   double *, double *, double *, double *, double *, double *,
                   double *, double *, double *, double *, double *, double *,
                   int, size_t, unsigned short int, unsigned short int, double,
-                  size_t, int, int *, double *, double *, dmy_struct *,
+                  size_t, int *, double *, double *, dmy_struct *,
                   force_data_struct *, energy_bal_struct *, layer_data_struct *,
-                  snow_data_struct *, soil_con_struct *, veg_var_struct *);
+                  snow_data_struct *, soil_con_struct *, veg_var_struct *, veg_lib_struct *);
 double solve_surf_energy_bal(double Tsurf, ...);
 int solve_T_profile(double *, double *, char *, unsigned int *, double *,
                     double *, double *, double *, double, double *, double *,
@@ -294,18 +294,18 @@ double sub_with_height(double z, double es, double Wind, double AirDens,
 int surface_fluxes(bool, double, double, double, double, double *, double *,
                    double *, double *, double *, double *, double *, double *,
                    double *, double *, double *, double *, double *, size_t,
-                   size_t, unsigned short int, double, unsigned short int,
+                   size_t, unsigned short int, double,
                    unsigned short int, force_data_struct *, dmy_struct *,
                    energy_bal_struct *, global_param_struct *,
                    cell_data_struct *, snow_data_struct *, soil_con_struct *,
-                   veg_var_struct *, double, double, double, double *);
+                   veg_var_struct *, veg_lib_struct *, double, double, double, double *);
 double svp(double);
 double svp_slope(double);
 void temp_area(double, double, double, double *, double *, double *, double *,
                double, double *, int, double, double, double *, double *,
                double *);
 void tracer_mixer(double *, int *, double *, int, double, double, double *);
-void transpiration(layer_data_struct *, veg_var_struct *, unsigned short int,
+void transpiration(layer_data_struct *, veg_var_struct *, veg_lib_struct *,
                    double, double, double, double, double, double, double,
                    double, double *, double *, double *, double *, double *,
                    double *, double, double, double *);

--- a/vic/vic_run/src/calc_surf_energy_bal.c
+++ b/vic/vic_run/src/calc_surf_energy_bal.c
@@ -77,7 +77,6 @@ calc_surf_energy_bal(double             Le,
                      size_t             hidx,
                      unsigned short     iveg,
                      int                overstory,
-                     unsigned short     veg_class,
                      double            *CanopLayerBnd,
                      double            *dryFrac,
                      force_data_struct *force,
@@ -86,7 +85,8 @@ calc_surf_energy_bal(double             Le,
                      layer_data_struct *layer,
                      snow_data_struct  *snow,
                      soil_con_struct   *soil_con,
-                     veg_var_struct    *veg_var)
+                     veg_var_struct    *veg_var,
+                     veg_lib_struct    *veg_lib)
 {
     extern option_struct     options;
     extern parameters_struct param;
@@ -299,7 +299,7 @@ calc_surf_energy_bal(double             Le,
         }
 
         Tsurf = root_brent(T_lower, T_upper, func_surf_energy_bal,
-                           VEG, veg_class, delta_t, Cs1, Cs2, D1, D2,
+                           VEG, delta_t, Cs1, Cs2, D1, D2,
                            T1_old, T2, Ts_old, energy->T, bubble, dp, expt,
                            ice0, kappa1, kappa2, max_moist, moist, root,
                            CanopLayerBnd, UnderStory, overstory, NetShortBare,
@@ -318,7 +318,7 @@ calc_surf_energy_bal(double             Le,
                            Tnew_node, Tnew_fbflag, Tnew_fbcount, alpha, beta,
                            bubble_node, Zsum_node, expt_node, gamma, ice_node,
                            kappa_node, max_moist_node, moist_node, soil_con,
-                           layer, veg_var, INCLUDE_SNOW, options.NOFLUX,
+                           layer, veg_var, veg_lib, INCLUDE_SNOW, options.NOFLUX,
                            options.EXP_TRANS,
                            snow->snow, FIRST_SOLN, &NetLongBare,
                            &TmpNetLongSnow, &T1, &energy->deltaH,
@@ -340,7 +340,7 @@ calc_surf_energy_bal(double             Le,
                                                    (int) dmy->day,
                                                    (int) dmy->dayseconds,
                                                    VEG, iveg,
-                                                   veg_class, delta_t, Cs1, Cs2,
+                                                   delta_t, Cs1, Cs2,
                                                    D1, D2,
                                                    T1_old, T2, Ts_old,
                                                    energy->T,
@@ -390,7 +390,7 @@ calc_surf_energy_bal(double             Le,
                                                    gamma, ice_node, kappa_node,
                                                    max_moist_node, moist_node,
                                                    soil_con->frost_fract,
-                                                   layer, veg_var,
+                                                   layer, veg_var, veg_lib,
                                                    INCLUDE_SNOW,
                                                    soil_con->FS_ACTIVE,
                                                    options.NOFLUX,
@@ -419,7 +419,7 @@ calc_surf_energy_bal(double             Le,
             FIRST_SOLN[0] = true;
 
             Tsurf = root_brent(T_lower, T_upper,
-                               func_surf_energy_bal, VEG, veg_class,
+                               func_surf_energy_bal, VEG,
                                delta_t, Cs1, Cs2, D1, D2, T1_old, T2, Ts_old,
                                energy->T, bubble, dp, expt, ice0, kappa1,
                                kappa2, max_moist, moist, root, CanopLayerBnd,
@@ -441,7 +441,7 @@ calc_surf_energy_bal(double             Le,
                                Tnew_node, Tnew_fbflag, Tnew_fbcount, alpha,
                                beta, bubble_node, Zsum_node, expt_node, gamma,
                                ice_node, kappa_node, max_moist_node,
-                               moist_node, soil_con, layer, veg_var,
+                               moist_node, soil_con, layer, veg_var, veg_lib,
                                INCLUDE_SNOW, options.NOFLUX, options.EXP_TRANS,
                                snow->snow,
                                FIRST_SOLN, &NetLongBare, &TmpNetLongSnow, &T1,
@@ -462,7 +462,7 @@ calc_surf_energy_bal(double             Le,
                                                        (int) dmy->day,
                                                        (int) dmy->dayseconds,
                                                        VEG, iveg,
-                                                       veg_class, delta_t, Cs1,
+                                                       delta_t, Cs1,
                                                        Cs2, D1,
                                                        D2, T1_old, T2, Ts_old,
                                                        energy->T,
@@ -518,7 +518,7 @@ calc_surf_energy_bal(double             Le,
                                                        max_moist_node,
                                                        moist_node,
                                                        soil_con->frost_fract,
-                                                       layer, veg_var,
+                                                       layer, veg_var, veg_lib,
                                                        INCLUDE_SNOW,
                                                        soil_con->FS_ACTIVE,
                                                        options.NOFLUX,
@@ -549,7 +549,7 @@ calc_surf_energy_bal(double             Le,
         FIRST_SOLN[0] = true;
     }
 
-    error = solve_surf_energy_bal(Tsurf, VEG, veg_class, delta_t, Cs1,
+    error = solve_surf_energy_bal(Tsurf, VEG, delta_t, Cs1,
                                   Cs2, D1, D2, T1_old, T2, Ts_old, energy->T,
                                   bubble, dp, expt, ice0, kappa1, kappa2,
                                   max_moist, moist, root, CanopLayerBnd,
@@ -572,7 +572,7 @@ calc_surf_energy_bal(double             Le,
                                   alpha, beta, bubble_node, Zsum_node,
                                   expt_node, gamma, ice_node, kappa_node,
                                   max_moist_node, moist_node, soil_con, layer,
-                                  veg_var, INCLUDE_SNOW, options.NOFLUX,
+                                  veg_var, veg_lib, INCLUDE_SNOW, options.NOFLUX,
                                   options.EXP_TRANS,
                                   snow->snow, FIRST_SOLN, &NetLongBare,
                                   &TmpNetLongSnow, &T1, &energy->deltaH,
@@ -803,7 +803,6 @@ error_print_surf_energy_bal(double  Ts,
     int                sec;
     int                iveg;
     int                VEG;
-    int                veg_class;
 
     double             delta_t;
 
@@ -908,6 +907,7 @@ error_print_surf_energy_bal(double  Ts,
     /* model structures */
     layer_data_struct *layer;
     veg_var_struct    *veg_var;
+    veg_lib_struct    *veg_lib;
 
     /* control flags */
     int                INCLUDE_SNOW;
@@ -946,7 +946,6 @@ error_print_surf_energy_bal(double  Ts,
     sec = (int) va_arg(ap, int);
     VEG = (int) va_arg(ap, int);
     iveg = (int) va_arg(ap, int);
-    veg_class = (int) va_arg(ap, int);
 
     delta_t = (double) va_arg(ap, double);
 
@@ -1049,6 +1048,7 @@ error_print_surf_energy_bal(double  Ts,
     /* model structures */
     layer = (layer_data_struct *) va_arg(ap, layer_data_struct *);
     veg_var = (veg_var_struct *) va_arg(ap, veg_var_struct *);
+    veg_lib = (veg_lib_struct *) va_arg(ap, veg_lib_struct *);
 
     /* control flags */
     INCLUDE_SNOW = (int) va_arg(ap, int);
@@ -1088,7 +1088,6 @@ error_print_surf_energy_bal(double  Ts,
     fprintf(LOG_DEST, "day = %i\n", day);
     fprintf(LOG_DEST, "second = %i\n", sec);
     fprintf(LOG_DEST, "VEG = %i\n", VEG);
-    fprintf(LOG_DEST, "veg_class = %i\n", veg_class);
     fprintf(LOG_DEST, "delta_t = %f\n", delta_t);
 
     /* soil layer terms */
@@ -1199,7 +1198,8 @@ error_print_surf_energy_bal(double  Ts,
 
     write_layer(layer, iveg, frost_fract);
     write_vegvar(&(veg_var[0]), iveg);
-
+    UNUSED(veg_lib);
+    
     if (!options.QUICK_FLUX) {
         fprintf(LOG_DEST,
                 "Node\tT\tTnew\tTold\talpha\tbeta\tZsum\tkappa\tCs\tmoist\t"

--- a/vic/vic_run/src/func_canopy_energy_bal.c
+++ b/vic/vic_run/src/func_canopy_energy_bal.c
@@ -65,8 +65,6 @@ func_canopy_energy_bal(double  Tfoliage,
     double                  *Wind;
 
     /* Vegetation Terms */
-    int                      veg_class;
-
     double                  *displacement;
     double                  *ref_height;
     double                  *roughness;
@@ -82,6 +80,7 @@ func_canopy_energy_bal(double  Tfoliage,
 
     layer_data_struct       *layer;
     veg_var_struct          *veg_var;
+    veg_lib_struct          *veg_lib;
 
     /* Energy Flux Terms */
     double                   LongOverIn;
@@ -133,8 +132,6 @@ func_canopy_energy_bal(double  Tfoliage,
     Wind = (double *) va_arg(ap, double *);
 
     /* Vegetation Terms */
-    veg_class = (unsigned int) va_arg(ap, unsigned int);
-
     displacement = (double *) va_arg(ap, double *);
     ref_height = (double *) va_arg(ap, double *);
     roughness = (double *) va_arg(ap, double *);
@@ -150,6 +147,7 @@ func_canopy_energy_bal(double  Tfoliage,
 
     layer = (layer_data_struct *) va_arg(ap, layer_data_struct *);
     veg_var = (veg_var_struct *) va_arg(ap, veg_var_struct *);
+    veg_lib = (veg_lib_struct *) va_arg(ap, veg_lib_struct *);
 
     /* Energy Flux Terms */
     LongOverIn = (double) va_arg(ap, double);
@@ -239,8 +237,8 @@ func_canopy_energy_bal(double  Tfoliage,
 
         *Wdew = IntRain * MM_PER_M;
         prec = Rainfall * MM_PER_M;
-        *Evap = canopy_evap(layer, veg_var, false,
-                            veg_class, Wdew, delta_t, *NetRadiation,
+        *Evap = canopy_evap(layer, veg_var, veg_lib, false,
+                            Wdew, delta_t, *NetRadiation,
                             Vpd, NetShortOver, Tcanopy, Ra_used[1],
                             elevation, prec, Wmax, Wcr, Wpwp, frost_fract,
                             root, dryFrac, shortwave, Catm, CanopLayerBnd);

--- a/vic/vic_run/src/func_surf_energy_bal.c
+++ b/vic/vic_run/src/func_surf_energy_bal.c
@@ -47,7 +47,6 @@ func_surf_energy_bal(double  Ts,
     /* general model terms */
     size_t             i;
     int                VEG;
-    int                veg_class;
     int                Error;
 
     double             delta_t;
@@ -163,6 +162,7 @@ func_surf_energy_bal(double  Ts,
     soil_con_struct   *soil_con;
     layer_data_struct *layer;
     veg_var_struct    *veg_var;
+    veg_lib_struct    *veg_lib;
 
     /* control flags */
     int                INCLUDE_SNOW;
@@ -220,7 +220,6 @@ func_surf_energy_bal(double  Ts,
 
     /* general model terms */
     VEG = (int) va_arg(ap, int);
-    veg_class = (int) va_arg(ap, int);
     delta_t = (double) va_arg(ap, double);
 
     /* soil layer terms */
@@ -317,6 +316,7 @@ func_surf_energy_bal(double  Ts,
     soil_con = (soil_con_struct *) va_arg(ap, soil_con_struct *);
     layer = (layer_data_struct *) va_arg(ap, layer_data_struct *);
     veg_var = (veg_var_struct *) va_arg(ap, veg_var_struct *);
+    veg_lib = (veg_lib_struct *) va_arg(ap, veg_lib_struct *);
 
     /* control flags */
     INCLUDE_SNOW = (int) va_arg(ap, int);
@@ -751,7 +751,7 @@ func_surf_energy_bal(double  Ts,
     Evap = 0.;
     if (!SNOWING) {
         if (VEG && veg_var->fcanopy > 0) {
-            Evap = canopy_evap(layer, veg_var, true, veg_class, Wdew,
+            Evap = canopy_evap(layer, veg_var, veg_lib, true, Wdew,
                                delta_t, NetBareRad, vpd, NetShortBare,
                                Tair, Ra_veg[1], elevation, rainfall,
                                Wmax, Wcr, Wpwp, frost_fract, root,

--- a/vic/vic_run/src/snow_intercept.c
+++ b/vic/vic_run/src/snow_intercept.c
@@ -71,13 +71,13 @@ snow_intercept(double             Dt,
                int                iveg,
                int                month,
                int                hidx,
-               unsigned short     veg_class,
                double            *CanopLayerBnd,
                double            *dryFrac,
                force_data_struct *force,
                layer_data_struct *layer,
                soil_con_struct   *soil_con,
-               veg_var_struct    *veg_var)
+               veg_var_struct    *veg_var,
+               veg_lib_struct    *veg_lib)
 {
     extern option_struct     options;
     extern parameters_struct param;
@@ -303,10 +303,10 @@ snow_intercept(double             Dt,
                                        soil_con->Wpwp, soil_con->frost_fract,
                                        AirDens, EactAir, Press, Le, Tcanopy,
                                        Vpd, shortwave, Catm, dryFrac, &Evap,
-                                       Ra, Ra_used, *RainFall, Wind, veg_class,
+                                       Ra, Ra_used, *RainFall, Wind,
                                        displacement, ref_height, roughness,
                                        root, CanopLayerBnd, IntRainOrg,
-                                       *IntSnow, IntRain, layer, veg_var,
+                                       *IntSnow, IntRain, layer, veg_var, veg_lib,
                                        LongOverIn, LongUnderOut, *NetShortOver,
                                        AdvectedEnergy, LatentHeat,
                                        LatentHeatSub, LongOverOut, NetLongOver,
@@ -345,10 +345,10 @@ snow_intercept(double             Dt,
                                AirDens, EactAir, Press, Le,
                                Tcanopy, Vpd, shortwave, Catm, dryFrac,
                                &Evap, Ra, Ra_used, *RainFall, Wind,
-                               veg_class, displacement, ref_height,
+                               displacement, ref_height,
                                roughness, root, CanopLayerBnd, IntRainOrg,
                                *IntSnow,
-                               IntRain, layer, veg_var,
+                               IntRain, layer, veg_var, veg_lib,
                                LongOverIn, LongUnderOut,
                                *NetShortOver,
                                AdvectedEnergy,
@@ -377,12 +377,12 @@ snow_intercept(double             Dt,
                                                     &Evap, Ra, Ra_used,
                                                     *RainFall, Wind, UnderStory,
                                                     iveg,
-                                                    veg_class, displacement,
+                                                    displacement,
                                                     ref_height,
                                                     roughness, root,
                                                     CanopLayerBnd, IntRainOrg,
                                                     *IntSnow,
-                                                    IntRain, layer, veg_var,
+                                                    IntRain, layer, veg_var, veg_lib,
                                                     LongOverIn, LongUnderOut,
                                                     *NetShortOver,
                                                     AdvectedEnergy,
@@ -401,10 +401,10 @@ snow_intercept(double             Dt,
                                        soil_con->Wpwp, soil_con->frost_fract,
                                        AirDens, EactAir, Press, Le, Tcanopy,
                                        Vpd, shortwave, Catm, dryFrac, &Evap,
-                                       Ra, Ra_used, *RainFall, Wind, veg_class,
+                                       Ra, Ra_used, *RainFall, Wind,
                                        displacement, ref_height, roughness,
                                        root, CanopLayerBnd, IntRainOrg,
-                                       *IntSnow, IntRain, layer, veg_var,
+                                       *IntSnow, IntRain, layer, veg_var, veg_lib,
                                        LongOverIn, LongUnderOut, *NetShortOver,
                                        AdvectedEnergy, LatentHeat,
                                        LatentHeatSub, LongOverOut, NetLongOver,
@@ -638,7 +638,6 @@ error_print_canopy_energy_bal(double  Tfoliage,
     /* Vegetation Terms */
     int                  UnderStory;
     int                  iveg;
-    unsigned int         veg_class;
 
     double              *displacement;
     double              *ref_height;
@@ -655,6 +654,7 @@ error_print_canopy_energy_bal(double  Tfoliage,
 
     layer_data_struct   *layer;
     veg_var_struct      *veg_var;
+    veg_lib_struct      *veg_lib;
 
     /* Energy Flux Terms */
     double               LongOverIn;
@@ -708,7 +708,6 @@ error_print_canopy_energy_bal(double  Tfoliage,
     /* Vegetation Terms */
     UnderStory = (int) va_arg(ap, int);
     iveg = (int) va_arg(ap, int);
-    veg_class = (unsigned int) va_arg(ap, unsigned int);
 
     displacement = (double *) va_arg(ap, double *);
     ref_height = (double *) va_arg(ap, double *);
@@ -725,6 +724,7 @@ error_print_canopy_energy_bal(double  Tfoliage,
 
     layer = (layer_data_struct *) va_arg(ap, layer_data_struct *);
     veg_var = (veg_var_struct *) va_arg(ap, veg_var_struct *);
+    veg_lib = (veg_lib_struct *) va_arg(ap, veg_lib_struct *);
 
     /* Energy Flux Terms */
     LongOverIn = (double) va_arg(ap, double);
@@ -779,7 +779,6 @@ error_print_canopy_energy_bal(double  Tfoliage,
     /* Vegetation Terms */
     fprintf(LOG_DEST, "UnderStory = %i\n", UnderStory);
     fprintf(LOG_DEST, "iveg = %i\n", iveg);
-    fprintf(LOG_DEST, "veg_class = %i\n", veg_class);
 
     fprintf(LOG_DEST, "displacement = [%f, %f]\n", displacement[1],
             displacement[UnderStory]);
@@ -806,6 +805,7 @@ error_print_canopy_energy_bal(double  Tfoliage,
 
     write_layer(layer, iveg, frost_fract);
     write_vegvar(&(veg_var[0]), iveg);
+    UNUSED(veg_lib);
 
     fprintf(LOG_DEST, "Tfoliage = %f\n", Tfoliage);
 

--- a/vic/vic_run/src/solve_snow.c
+++ b/vic/vic_run/src/solve_snow.c
@@ -78,7 +78,6 @@ solve_snow(char               overstory,
            unsigned short     band,
            double             dt,
            size_t             hidx,
-           int                veg_class,
            int               *UnderStory,
            double            *CanopLayerBnd,
            double            *dryFrac,
@@ -88,7 +87,8 @@ solve_snow(char               overstory,
            layer_data_struct *layer,
            snow_data_struct  *snow,
            soil_con_struct   *soil_con,
-           veg_var_struct    *veg_var)
+           veg_var_struct    *veg_var,
+           veg_lib_struct    *veg_lib)
 {
     extern option_struct     options;
     extern parameters_struct param;
@@ -216,9 +216,8 @@ solve_snow(char               overstory,
                                            ref_height, roughness, root,
                                            *UnderStory, band,
                                            iveg, month, hidx,
-                                           veg_class,
                                            CanopLayerBnd, dryFrac, force,
-                                           layer, soil_con, veg_var);
+                                           layer, soil_con, veg_var, veg_lib);
                 if (ErrorFlag == ERROR) {
                     return (ERROR);
                 }

--- a/vic/vic_run/src/surface_fluxes.c
+++ b/vic/vic_run/src/surface_fluxes.c
@@ -55,7 +55,6 @@ surface_fluxes(bool                 overstory,
                unsigned short       band,
                double               dp,
                unsigned short       iveg,
-               unsigned short       veg_class,
                force_data_struct   *force,
                dmy_struct          *dmy,
                energy_bal_struct   *energy,
@@ -64,12 +63,12 @@ surface_fluxes(bool                 overstory,
                snow_data_struct    *snow,
                soil_con_struct     *soil_con,
                veg_var_struct      *veg_var,
+               veg_lib_struct      *veg_lib,
                double               lag_one,
                double               sigma_slope,
                double               fetch,
                double              *CanopLayerBnd)
 {
-    extern veg_lib_struct   *vic_run_veg_lib;
     extern option_struct     options;
     extern parameters_struct param;
 
@@ -560,12 +559,11 @@ surface_fluxes(bool                 overstory,
                                        &surf_atten,
                                        wind, root, UNSTABLE_SNOW,
                                        Nveg, iveg, band, step_dt, hidx,
-                                       veg_class,
                                        &UnderStory, CanopLayerBnd, &dryFrac,
                                        dmy, force, &(iter_snow_energy),
                                        iter_layer, &(iter_snow),
                                        soil_con,
-                                       &(iter_snow_veg_var));
+                                       &(iter_snow_veg_var), veg_lib);
 
                 if (step_melt == ERROR) {
                     return (ERROR);
@@ -614,12 +612,12 @@ surface_fluxes(bool                 overstory,
                                              snowfall, wind, root, INCLUDE_SNOW,
                                              UnderStory, options.Nnode, Nveg,
                                              step_dt, hidx, iveg,
-                                             (int) overstory, veg_class,
+                                             (int) overstory,
                                              CanopLayerBnd, &dryFrac, force,
                                              dmy, &iter_soil_energy,
                                              iter_layer,
                                              &(iter_snow), soil_con,
-                                             &iter_soil_veg_var);
+                                             &iter_soil_veg_var, veg_lib);
 
                 if ((int) Tsurf == ERROR) {
                     // Return error flag to skip rest of grid cell
@@ -726,10 +724,10 @@ surface_fluxes(bool                 overstory,
         **************************************/
         if (options.CARBON) {
             if (iveg < Nveg && !step_snow.snow && dryFrac > 0) {
-                canopy_assimilation(vic_run_veg_lib[veg_class].Ctype,
-                                    vic_run_veg_lib[veg_class].MaxCarboxRate,
-                                    vic_run_veg_lib[veg_class].MaxETransport,
-                                    vic_run_veg_lib[veg_class].CO2Specificity,
+                canopy_assimilation(veg_lib->Ctype,
+                                    veg_lib->MaxCarboxRate,
+                                    veg_lib->MaxETransport,
+                                    veg_lib->CO2Specificity,
                                     iter_soil_veg_var.NscaleFactor,
                                     Tair,
                                     force->shortwave[hidx],
@@ -788,14 +786,14 @@ surface_fluxes(bool                 overstory,
         **************************************/
 
         compute_pot_evap(gp->model_steps_per_day,
-                         vic_run_veg_lib[veg_class].rmin,
+                         veg_lib->rmin,
                          iter_soil_veg_var.albedo, force->shortwave[hidx],
                          iter_soil_energy.NetLongAtmos,
-                         vic_run_veg_lib[veg_class].RGL, Tair, VPDcanopy,
+                         veg_lib->RGL, Tair, VPDcanopy,
                          iter_soil_veg_var.LAI, soil_con->elevation,
                          iter_aero_resist_veg,
-                         vic_run_veg_lib[veg_class].overstory,
-                         vic_run_veg_lib[veg_class].rarc,
+                         veg_lib->overstory,
+                         veg_lib->rarc,
                          iter_soil_veg_var.fcanopy, iter_aero_resist_used[0],
                          &iter_pot_evap);
 

--- a/vic/vic_run/src/vic_run.c
+++ b/vic/vic_run/src/vic_run.c
@@ -27,8 +27,6 @@
 
 #include <vic_run.h>
 
-veg_lib_struct *vic_run_veg_lib;
-
 /******************************************************************************
 * @brief        This subroutine controls the model core, it solves both the
 *               energy and water balance models, as well as frozen soils.
@@ -103,11 +101,6 @@ vic_run(force_data_struct   *force,
     check_alloc_status(Melt, "Memory allocation error.");
     snow_inflow = calloc(options.SNOW_BAND, sizeof(*snow_inflow));
     check_alloc_status(snow_inflow, "Memory allocation error.");
-
-    // assign vic_run_veg_lib to veg_lib, so that the veg_lib for the correct
-    // grid cell is used within vic_run. For simplicity sake, use vic_run_veg_lib
-    // everywhere within vic_run
-    vic_run_veg_lib = veg_lib;
 
     /* set local pointers */
     lake_var = &all_vars->lake_var;
@@ -185,7 +178,7 @@ vic_run(force_data_struct   *force,
 
             /** Assign wind_h **/
             /** Note: this is ignored below **/
-            wind_h = vic_run_veg_lib[veg_class].wind_h;
+            wind_h = veg_lib[veg_class].wind_h;
 
             /* Initialize wind speeds */
             tmp_wind[0] = force->wind[NR];
@@ -198,7 +191,7 @@ vic_run(force_data_struct   *force,
             if (roughness[0] == 0) {
                 roughness[0] = soil_con->rough;
             }
-            overstory = vic_run_veg_lib[veg_class].overstory;
+            overstory = veg_lib[veg_class].overstory;
 
             /* Estimate vegetation height */
             height = calc_veg_height(displacement[0]);
@@ -213,9 +206,9 @@ vic_run(force_data_struct   *force,
 
             /* Compute aerodynamic resistance */
             ErrorFlag = CalcAerodynamic(overstory, height,
-                                        vic_run_veg_lib[veg_class].trunk_ratio,
+                                        veg_lib[veg_class].trunk_ratio,
                                         soil_con->snow_rough, soil_con->rough,
-                                        vic_run_veg_lib[veg_class].wind_atten,
+                                        veg_lib[veg_class].wind_atten,
                                         aero_resist, tmp_wind,
                                         displacement, ref_height,
                                         roughness);
@@ -247,7 +240,7 @@ vic_run(force_data_struct   *force,
 
                     /** Surface Attenuation due to Vegetation Coverage **/
                     surf_atten = (1 - veg_var->fcanopy) * 1.0 +
-                                 veg_var->fcanopy *exp(-vic_run_veg_lib[veg_class].rad_atten *
+                                 veg_var->fcanopy *exp(-veg_lib[veg_class].rad_atten *
                                                        veg_var->LAI);
 
                     /** Bare (free of snow) Albedo **/
@@ -280,7 +273,7 @@ vic_run(force_data_struct   *force,
                             veg_var->aPAR = 0;
 
                             calc_Nscale_factors(
-                                vic_run_veg_lib[veg_class].NscaleFlag,
+                                veg_lib[veg_class].NscaleFlag,
                                 veg_con[iveg].CanopLayerBnd,
                                 veg_var->LAI,
                                 force->coszen[NR],
@@ -328,10 +321,10 @@ vic_run(force_data_struct   *force,
                                                &snow_inflow[band],
                                                tmp_wind, veg_con[iveg].root,
                                                options.Nlayer, Nveg, band, dp,
-                                               iveg, veg_class, force, dmy,
+                                               iveg, force, dmy,
                                                energy, gp, cell, snow,
-                                               soil_con, veg_var, lag_one,
-                                               sigma_slope, fetch,
+                                               soil_con, veg_var, &(veg_lib[veg_class]), 
+                                               lag_one, sigma_slope, fetch,
                                                veg_con[iveg].CanopLayerBnd);
 
                     if (ErrorFlag == ERROR) {


### PR DESCRIPTION
The vic_run_veg_lib variable is used to communicate the vegetation library (veg_lib) to other functions using an external variable. Each cell iteration overwrites the vic_run_veg_lib variable. However, when using MP the variable is overwritten by each separate process. Therefore vegetation information could be from the a different cell currently processed by MP. 

This is not a problem with the current (global) vegetation parameters of VIC, since they are the same for every cell in the simulation. However, for my personal project some parameters (e.g. LAI, veg_rough, displacement etc.) vary per cell, which causes errors.

To fix this the vic_run_veg_lib variable was deleted and the veg_lib is used directly. This also required several functions to use the vegetation library as an input directly, instead of combining the vegetation class with the vic_run_veg_lib variable.

For the image domain it would be possible to store all veg_lib parameters in the veg_con. The veg_con parameters are only allocated if vegetation is actually present, which would both decrease memory usage and remove these kinds of errors. 